### PR TITLE
python: add server listener for subscribe/unsubscribe callbacks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
+// -*- jsonc -*-
 {
   "editor.formatOnSave": true,
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,20 @@
 {
   "editor.formatOnSave": true,
-  "python.formatting.provider": "black",
-  "python.analysis.typeCheckingMode": "strict",
+
   "typescript.tsdk": "node_modules/typescript/lib",
   "prettier.prettierPath": "./node_modules/prettier",
   "eslint.packageManager": "yarn",
   "eslint.options": {
     "reportUnusedDisableDirectives": true
   },
+
   "python.analysis.diagnosticSeverityOverrides": {
     // produces spurious errors when importing local packages from tests
     "reportMissingTypeStubs": "none"
-  }
+  },
+  "python.testing.pytestArgs": ["python"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.formatting.provider": "black",
+  "python.analysis.typeCheckingMode": "strict"
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
+addopts = '-vv'
 log_cli = true

--- a/python/src/foxglove_websocket/server.py
+++ b/python/src/foxglove_websocket/server.py
@@ -44,10 +44,16 @@ class Client:
 class FoxgloveServerListener(ABC):
     @abstractmethod
     def on_subscribe(self, server: "FoxgloveServer", channel_id: ChannelId):
+        """
+        Called when the first client subscribes to `channel_id`.
+        """
         ...
 
     @abstractmethod
     def on_unsubscribe(self, server: "FoxgloveServer", channel_id: ChannelId):
+        """
+        Called when the last subscribed client unsubscribes from `channel_id`.
+        """
         ...
 
 

--- a/python/src/foxglove_websocket/server.py
+++ b/python/src/foxglove_websocket/server.py
@@ -1,8 +1,10 @@
+from abc import ABC, abstractmethod
 import asyncio
 import json
 import logging
 from struct import Struct
-from typing import Any, Dict, Set, cast
+from typing import Any, Dict, Optional, Set, cast
+from websockets.legacy.server import WebSocketServer
 from websockets.server import serve, WebSocketServerProtocol
 from websockets.exceptions import ConnectionClosed
 from dataclasses import dataclass
@@ -39,16 +41,28 @@ class Client:
     subscriptions_by_channel: Dict[ChannelId, Set[SubscriptionId]]
 
 
+class FoxgloveServerListener(ABC):
+    @abstractmethod
+    def on_subscribe(self, server: "FoxgloveServer", channel_id: ChannelId):
+        ...
+
+    @abstractmethod
+    def on_unsubscribe(self, server: "FoxgloveServer", channel_id: ChannelId):
+        ...
+
+
 class FoxgloveServer:
     _clients: Dict[WebSocketServerProtocol, Client]
     _channels: Dict[ChannelId, Channel]
     _next_channel_id: ChannelId
     _logger: logging.Logger
+    _listener: Optional[FoxgloveServerListener]
+    _opened: "asyncio.Future[WebSocketServer]"
 
     def __init__(
         self,
         host: str,
-        port: int,
+        port: Optional[int],
         name: str,
         *,
         logger: logging.Logger = _get_default_logger(),
@@ -60,6 +74,17 @@ class FoxgloveServer:
         self._channels = {}
         self._next_channel_id = ChannelId(0)
         self._logger = logger
+        self._listener = None
+        self._opened = asyncio.get_running_loop().create_future()
+
+    def set_listener(self, listener: FoxgloveServerListener):
+        self._listener = listener
+
+    def _any_subscribed(self, chan_id: ChannelId):
+        return any(
+            chan_id in client.subscriptions_by_channel
+            for client in self._clients.values()
+        )
 
     async def __aenter__(self):
         self.start()
@@ -69,6 +94,9 @@ class FoxgloveServer:
         self.close()
         await self.wait_closed()
 
+    async def wait_opened(self):
+        return await self._opened
+
     def start(self):
         self._task = asyncio.create_task(self._run())
 
@@ -77,7 +105,10 @@ class FoxgloveServer:
         self._task.cancel()
 
     async def wait_closed(self):
-        await self._task
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
 
     async def _run(self):
         # TODO: guard against multiple run calls?
@@ -89,6 +120,7 @@ class FoxgloveServer:
                 self.port,
                 subprotocols=[Subprotocol("foxglove.websocket.v1")],
             )
+            self._opened.set_result(server)
         except asyncio.CancelledError:
             self._logger.info("Canceled during server startup")
             return
@@ -193,8 +225,12 @@ class FoxgloveServer:
             await connection.close(1011)  # Internal Error
 
         finally:
-            # TODO: invoke user unsubscribe callback
+            potential_unsubscribes = client.subscriptions_by_channel.keys()
             del self._clients[connection]
+            if self._listener:
+                for chan_id in potential_unsubscribes:
+                    if not self._any_subscribed(chan_id):
+                        self._listener.on_unsubscribe(self, chan_id)
 
     async def _handle_raw_client_message(self, client: Client, raw_message: Data):
         try:
@@ -207,7 +243,10 @@ class FoxgloveServer:
             if not isinstance(message, dict):
                 raise TypeError(f"Expected JSON object, got {type(message)}")
             await self._handle_client_message(client, cast(ClientMessage, message))
-
+        except ConnectionClosed:
+            self._logger.debug(
+                "Client connection closed while handling message %s", raw_message
+            )
         except Exception as exc:
             self._logger.exception("Error handling message %s", raw_message)
             await self._send_json(
@@ -220,10 +259,6 @@ class FoxgloveServer:
             )
 
     async def _handle_client_message(self, client: Client, message: ClientMessage):
-        # if message["op"] == ClientOpcode.LIST_CHANNELS:
-        #     await self._send_json(
-        #         client.connection, {"op": ServerOpcode.CHANNEL_LIST, "channels": []}
-        #     )
         if message["op"] == "subscribe":
             for sub in message["subscriptions"]:
                 chan_id = sub["channelId"]
@@ -254,9 +289,11 @@ class FoxgloveServer:
                     client.connection.remote_address,
                     chan_id,
                 )
-                # TODO: invoke user subscribe callback
+                first_subscription = not self._any_subscribed(chan_id)
                 client.subscriptions[sub_id] = chan_id
                 client.subscriptions_by_channel.setdefault(chan_id, set()).add(sub_id)
+                if self._listener and first_subscription:
+                    self._listener.on_subscribe(self, chan_id)
 
         elif message["op"] == "unsubscribe":
             for sub_id in message["subscriptionIds"]:
@@ -276,12 +313,13 @@ class FoxgloveServer:
                     client.connection.remote_address,
                     chan_id,
                 )
-                # TODO: invoke user unsubscribe callback
                 del client.subscriptions[sub_id]
                 subs = client.subscriptions_by_channel.get(chan_id)
                 if subs is not None:
                     subs.remove(sub_id)
                     if len(subs) == 0:
                         del client.subscriptions_by_channel[chan_id]
+                if self._listener and not self._any_subscribed(chan_id):
+                    self._listener.on_unsubscribe(self, chan_id)
         else:
             raise ValueError(f"Unrecognized client opcode: {message['op']}")

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -1,12 +1,139 @@
 import asyncio
+import json
+import logging
 import pytest
-from foxglove_websocket.server import FoxgloveServer
+from socket import AddressFamily
+from typing import List, Tuple
+from websockets.client import connect
+from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
+from foxglove_websocket.types import ChannelId
+from websockets.legacy.server import WebSocketServer
+
+
+def get_server_url(server: WebSocketServer):
+    """
+    Return a url that can be used to connect to the test server.
+    """
+    assert server.sockets
+    for sock in server.sockets:
+        if sock.family == AddressFamily.AF_INET:
+            return f"ws://{sock.getsockname()[0]}:{sock.getsockname()[1]}"
+        elif sock.family == AddressFamily.AF_INET6:  # type: ignore
+            return f"ws://[{sock.getsockname()[0]}]:{sock.getsockname()[1]}"
+    raise RuntimeError("Expected IPv4 or IPv6 socket")
 
 
 @pytest.mark.asyncio
-async def test_server():
-    server = FoxgloveServer("0.0.0.0", 0, "test server")
+async def test_shutdown_before_startup():
+    server = FoxgloveServer("localhost", None, "test server")
+    server.start()
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_startup():
+    server = FoxgloveServer("localhost", None, "test server")
     server.start()
     await asyncio.sleep(0)
     server.close()
     await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_after_startup():
+    server = FoxgloveServer("localhost", None, "test server")
+    server.start()
+    await server.wait_opened()
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_warn_invalid_channel():
+    async with FoxgloveServer("localhost", None, "test server") as server:
+        async with connect(get_server_url(await server.wait_opened())) as ws:
+            assert json.loads(await ws.recv())["op"] == "serverInfo"
+            assert json.loads(await ws.recv())["op"] == "advertise"
+            await ws.send(
+                json.dumps(
+                    {
+                        "op": "subscribe",
+                        "subscriptions": [{"id": 42, "channelId": 999}],
+                    }
+                )
+            )
+            assert json.loads(await ws.recv()) == {
+                "op": "status",
+                "level": 1,
+                "message": "Channel 999 is not available; ignoring subscription",
+            }
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_send(caplog: pytest.LogCaptureFixture):
+    async with FoxgloveServer("localhost", None, "test server") as server:
+        async with connect(get_server_url(await server.wait_opened())) as ws:
+            await ws.send(
+                json.dumps(
+                    {
+                        "op": "subscribe",
+                        "subscriptions": [{"id": 42, "channelId": 999}],
+                    }
+                )
+            )
+
+    for record in caplog.records:
+        assert record.levelno < logging.ERROR, str(record)
+
+
+@pytest.mark.asyncio
+async def test_listener_callbacks():
+    listener_calls: List[Tuple[str, ChannelId]] = []
+
+    class Listener(FoxgloveServerListener):
+        def on_subscribe(self, server: FoxgloveServer, channel_id: ChannelId):
+            listener_calls.append(("subscribe", channel_id))
+
+        def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
+            listener_calls.append(("unsubscribe", channel_id))
+
+    async with FoxgloveServer("localhost", None, "test server") as server:
+        server.set_listener(Listener())
+        ws_server = await server.wait_opened()
+        chan_id = await server.add_channel(
+            {
+                "topic": "t",
+                "encoding": "e",
+                "schemaName": "S",
+                "schema": "s",
+            }
+        )
+        async with connect(get_server_url(ws_server)) as ws:
+            assert json.loads(await ws.recv()) == {
+                "op": "serverInfo",
+                "name": "test server",
+                "capabilities": [],
+            }
+            assert json.loads(await ws.recv()) == {
+                "channels": [
+                    {
+                        "encoding": "e",
+                        "id": 0,
+                        "schema": "s",
+                        "schemaName": "S",
+                        "topic": "t",
+                    }
+                ],
+                "op": "advertise",
+            }
+            await ws.send(
+                json.dumps(
+                    {
+                        "op": "subscribe",
+                        "subscriptions": [{"id": 42, "channelId": chan_id}],
+                    }
+                )
+            )
+
+    assert listener_calls == [("subscribe", chan_id), ("unsubscribe", chan_id)]


### PR DESCRIPTION
Adds `server.set_listener()` to allow user code to handle subscribe/unsubscribe events.