### PR TITLE
Remove subscription and createDeserializer logic from TS client

### DIFF
--- a/typescript/scripts/example.ts
+++ b/typescript/scripts/example.ts
@@ -3,6 +3,7 @@ import protobufjs from "protobufjs";
 import { FileDescriptorSet } from "protobufjs/ext/descriptor";
 import WebSocket from "ws";
 
+import { SubscriptionId } from "../src";
 import FoxgloveClient from "../src/FoxgloveClient";
 
 async function main() {
@@ -12,19 +13,31 @@ async function main() {
   }
   const client = new FoxgloveClient({
     ws: new WebSocket(`ws://${host}:8765`, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
-    createDeserializer: (channel) => {
+  });
+  const deserializers = new Map<SubscriptionId, (data: DataView) => unknown>();
+  client.on("advertise", (channels) => {
+    for (const channel of channels) {
       if (channel.encoding !== "protobuf") {
-        throw new Error(`Unsupported encoding ${channel.encoding}`);
+        console.warn(`Unsupported encoding ${channel.encoding}`);
       }
       const root = protobufjs.Root.fromDescriptor(
         FileDescriptorSet.decode(Buffer.from(channel.schema, "base64")),
       );
       const type = root.lookupType(channel.schemaName);
-      return (data) => type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
-    },
+
+      const subId = client.subscribe(channel.id);
+      deserializers.set(subId, (data) =>
+        type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength)),
+      );
+    }
   });
-  client.on("message", console.log);
-  client.subscribe(topic);
+  client.on("message", ({ subscriptionId, timestamp, data }) => {
+    console.log({
+      subscriptionId,
+      timestamp,
+      data: deserializers.get(subscriptionId)!(data),
+    });
+  });
 }
 
 main().catch(console.error);

--- a/typescript/src/parse.ts
+++ b/typescript/src/parse.ts
@@ -9,12 +9,12 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
 
   switch (op as BinaryOpcode) {
     case BinaryOpcode.MESSAGE_DATA: {
-      const clientSubscriptionId = view.getUint32(offset, true);
+      const subscriptionId = view.getUint32(offset, true);
       offset += 4;
       const timestamp = view.getBigUint64(offset, true);
       offset += 8;
       const data = new DataView(buffer, offset);
-      return { op, clientSubscriptionId, timestamp, data };
+      return { op, subscriptionId, timestamp, data };
     }
   }
   throw new Error(`Unrecognized server opcode in binary message: ${op.toString(16)}`);

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -46,7 +46,7 @@ export type Unadvertise = {
 };
 export type MessageData = {
   op: BinaryOpcode.MESSAGE_DATA;
-  clientSubscriptionId: SubscriptionId;
+  subscriptionId: SubscriptionId;
   timestamp: bigint;
   data: DataView;
 };


### PR DESCRIPTION
In order to reuse parsed descriptors for deserialization and other purposes, Studio needs to be in control of its descriptor cache. The logic embedded in this client was making that difficult. The client API is now more similar to the actual protocol.
