### PR TITLE
Publish added/removed channels to clients after first connection

### DIFF
--- a/python/src/foxglove_websocket/types.py
+++ b/python/src/foxglove_websocket/types.py
@@ -63,7 +63,7 @@ class Advertise(TypedDict):
 
 class Unadvertise(TypedDict):
     op: Literal["unadvertise"]
-    channelsIds: List[ChannelId]
+    channelIds: List[ChannelId]
 
 
 ServerMessage = Union[ServerInfo, StatusMessage, Advertise, Unadvertise]


### PR DESCRIPTION
Python server now translates add_channel/remove_channel to advertise/unadvertise messages. Previously the channel list was only sent once to new clients upon connection.