### PR TITLE
Add `@latest` to all npx commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ pipenv shell
 
 ```
 python -m foxglove_websocket.examples.simple_server
-npx @foxglove/ws-protocol-examples sysmon
+npx @foxglove/ws-protocol-examples@latest sysmon
 ```
 
 ### Run example client
 
 ```
-npx @foxglove/ws-protocol-examples simple-client localhost:8765
+npx @foxglove/ws-protocol-examples@latest simple-client localhost:8765
 ```

--- a/typescript/ws-protocol-examples/README.md
+++ b/typescript/ws-protocol-examples/README.md
@@ -5,10 +5,10 @@ This package provides example server and client scripts using the [Foxglove Stud
 ## Usage
 
 ```
-$ npx @foxglove/ws-protocol-examples --help
-$ npx @foxglove/ws-protocol-examples image-server
-$ npx @foxglove/ws-protocol-examples sysmon
-$ npx @foxglove/ws-protocol-examples simple-client [host]
+$ npx @foxglove/ws-protocol-examples@latest --help
+$ npx @foxglove/ws-protocol-examples@latest image-server
+$ npx @foxglove/ws-protocol-examples@latest sysmon
+$ npx @foxglove/ws-protocol-examples@latest simple-client [host]
 ```
 
 To see data from the example servers, open up https://studio.foxglove.dev and initiate a Foxglove WebSocket connection to `ws://localhost:8765/`.

--- a/typescript/ws-protocol/README.md
+++ b/typescript/ws-protocol/README.md
@@ -22,7 +22,7 @@ $ npm install ws
 
 A system monitor script is provided as an illustrative example of a WebSocket server. To try it out:
 
-1. Run `npx @foxglove/ws-protocol-examples sysmon`.
+1. Run `npx @foxglove/ws-protocol-examples@latest sysmon`.
 2. In a browser, open up https://studio.foxglove.dev and initiate a Foxglove WebSocket connection to `ws://localhost:8765/`.
 
 <img width="500" alt="Foxglove Studio displaying memory and CPU usage from the system monitor example" src="https://user-images.githubusercontent.com/14237/145313065-85c05645-6b29-4eb2-a498-849c83f8792d.png">


### PR DESCRIPTION
Ensures the user always gets the latest version of the example scripts. By default npx might use an old version that's cached.