### PR TITLE
Add json decoding support to TypeScript simple-client example

### DIFF
--- a/typescript/ws-protocol-examples/README.md
+++ b/typescript/ws-protocol-examples/README.md
@@ -31,7 +31,7 @@ To see data from any server, open [Foxglove Studio](https://studio.foxglove.dev?
 
 ## Example client
 
-Run a simple example client that subscribes to messages with the `protobuf` encoding:
+Run a simple example client that subscribes to messages with the `protobuf` or `json` encoding:
 
 ```
 $ npx @foxglove/ws-protocol-examples@latest simple-client localhost:8765

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@foxglove/rostime": "^1.1.1",
-    "@foxglove/ws-protocol": "^0.0.6",
+    "@foxglove/ws-protocol": "^0.0.8",
     "boxen": "^6.2.1",
     "commander": "^8.3.0",
     "debug": "^4",

--- a/typescript/ws-protocol-examples/src/examples/image-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/image-server.ts
@@ -8,7 +8,7 @@ import { WebSocketServer } from "ws";
 
 import boxen from "../boxen";
 
-const log = Debug("foxglove:example-server");
+const log = Debug("foxglove:image-server");
 Debug.enable("foxglove:*");
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -55,7 +55,7 @@ function drawImage(time: number) {
 }
 
 async function main(): Promise<void> {
-  const server = new FoxgloveServer({ name: "example-server" });
+  const server = new FoxgloveServer({ name: "image-server" });
   const port = 8765;
   const ws = new WebSocketServer({
     port,

--- a/typescript/ws-protocol-examples/src/examples/simple-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/simple-client.ts
@@ -1,31 +1,42 @@
 import { FoxgloveClient, SubscriptionId } from "@foxglove/ws-protocol";
 import { Command } from "commander";
+import Debug from "debug";
 import protobufjs from "protobufjs";
 import { FileDescriptorSet } from "protobufjs/ext/descriptor";
 import WebSocket from "ws";
 
+const log = Debug("foxglove:simple-client");
+Debug.enable("foxglove:*");
+
 async function main(host: string) {
+  log(`Client connecting to ws://${host}`);
   const client = new FoxgloveClient({
     ws: new WebSocket(`ws://${host}`, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
   });
   const deserializers = new Map<SubscriptionId, (data: DataView) => unknown>();
   client.on("error", (error) => {
+    log("Error", error);
     throw error;
   });
   client.on("advertise", (channels) => {
     for (const channel of channels) {
-      if (channel.encoding !== "protobuf") {
+      if (channel.encoding === "json") {
+        const textDecoder = new TextDecoder();
+        const subId = client.subscribe(channel.id);
+        deserializers.set(subId, (data) => JSON.parse(textDecoder.decode(data)));
+      } else if (channel.encoding === "protobuf") {
+        const root = protobufjs.Root.fromDescriptor(
+          FileDescriptorSet.decode(Buffer.from(channel.schema, "base64")),
+        );
+        const type = root.lookupType(channel.schemaName);
+
+        const subId = client.subscribe(channel.id);
+        deserializers.set(subId, (data) =>
+          type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength)),
+        );
+      } else {
         console.warn(`Unsupported encoding ${channel.encoding}`);
       }
-      const root = protobufjs.Root.fromDescriptor(
-        FileDescriptorSet.decode(Buffer.from(channel.schema, "base64")),
-      );
-      const type = root.lookupType(channel.schemaName);
-
-      const subId = client.subscribe(channel.id);
-      deserializers.set(subId, (data) =>
-        type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength)),
-      );
     }
   });
   client.on("message", ({ subscriptionId, timestamp, data }) => {


### PR DESCRIPTION
**Public-Facing Changes**
`npx @foxglove/ws-protocol-examples simple-client` now supports JSON-encoded messages.


**Description**
Closes https://github.com/foxglove/ws-protocol/issues/31