### PR TITLE
Add threaded_server example

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -38,6 +38,20 @@ To see data from any server, open [Foxglove Studio](https://studio.foxglove.dev?
 
 To customize each server for your specifications, copy either server into a separate file like `server.py` and make the desired adjustments to this template. Start up your server from the command line, using `python3 server.py`.
 
+### Multi-threaded usage
+
+The [`threaded_server` example](https://github.com/foxglove/ws-protocol/blob/main/python/src/foxglove_websocket/examples/threaded_server/__main__.py) demonstrates how to use the `FoxgloveServer` class in a thread-safe way when interacting with a threaded middleware. Run the server using:
+
+```
+python -m foxglove_websocket.examples.threaded_server
+```
+
+When connected to the server in Foxglove Studio, use the [Data Source Info](https://foxglove.dev/docs/studio/panels/data-source-info) panel to see channels appearing and disappearing, and a [Plot](https://foxglove.dev/docs/studio/panels/plot) panel to visualize data on each channel.
+
+<img width="869" alt="image" src="https://user-images.githubusercontent.com/14237/154611361-37f87c06-b85f-4117-8bfe-e1bbbc31f7f4.png">
+
+For a more detailed explanation, read the [example's source code](https://github.com/foxglove/ws-protocol/blob/main/python/src/foxglove_websocket/examples/threaded_server/__main__.py).
+
 ## Development
 
 When developing or maintaining the `foxglove-websocket` package, it is recommended to use [`pipenv`](https://github.com/pypa/pipenv) to manage development dependencies and `virtualenv`.

--- a/python/src/foxglove_websocket/examples/threaded_server/__main__.py
+++ b/python/src/foxglove_websocket/examples/threaded_server/__main__.py
@@ -1,0 +1,141 @@
+import asyncio
+import logging
+from typing import Dict
+from foxglove_websocket import run_cancellable
+from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
+from foxglove_websocket.types import ChannelId, ChannelWithoutId
+
+from .middleware import ExampleMiddlewareThread, MiddlewareChannelId
+
+
+logger = logging.getLogger("threaded_server")
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setFormatter(
+    logging.Formatter("%(asctime)s: [%(levelname)s] <%(name)s> %(message)s")
+)
+logger.addHandler(handler)
+
+
+async def main():
+    """
+    This class illustrates how to make a Foxglove WebSocket server that interacts with a typical
+    threaded pub/sub middleware in a thread-safe way.
+
+    The FoxgloveServer class runs in an asyncio event loop, and it is *not* intrinsically
+    thread-safe (meaning that its methods cannot be called from threads other than the thread which
+    runs the event loop). However, many frameworks -- such as those that interact with multiprocess
+    pub/sub systems, drivers, or external hardware -- require the use of multiple threads. Luckily,
+    it is possible to use the FoxgloveServer safely in a multi-threaded program as long as some
+    synchronization primitives are used. This example script demonstrates the use of
+    `asyncio.run_coroutine_threadsafe()` to manage threads (and if you look under the hood of the
+    ExampleMiddlewareThread, you'll also see examples of `threading.Lock` and `threading.Event`).
+
+    In this example, we run the FoxgloveServer in the main thread (see `run_cancellable(main())`),
+    and start up the example middleware in a separate thread (`ExampleMiddlewareThread`). When the
+    middleware has new channels or message data available, it invokes our callback functions
+    (on_add_channel, on_remove_channel, on_message) in its own thread. To inform the FoxgloveServer
+    of these changes safely, we use `asyncio.run_coroutine_threadsafe()` to "hop" back over to the
+    main thread before calling methods on the server object.
+    """
+    middleware = ExampleMiddlewareThread()
+    loop = asyncio.get_event_loop()
+
+    async with FoxgloveServer("0.0.0.0", 8765, "example server") as server:
+        # Since the middleware may have its own notion of channels or topics, we need to keep track
+        # of which middleware channels correspond to which FoxgloveServer channels, so that we can
+        # forward message data from the middleware and subscribe/unsubscribe calls to the
+        # middleware.
+        id_map: Dict[MiddlewareChannelId, ChannelId] = {}
+        reverse_id_map: Dict[ChannelId, MiddlewareChannelId] = {}
+
+        # Configure callbacks that our middleware will call when channels are added or removed and
+        # when messages are received.
+        def on_add_channel(id: MiddlewareChannelId, channel: ChannelWithoutId):
+            """
+            When the middleware notifies us a channel is added, add it to the WebSocket server.
+            """
+
+            async def handler():
+                logger.info("Adding channel %d %s", id, channel["topic"])
+                ws_id = await server.add_channel(channel)
+                if id in id_map:
+                    raise Exception(
+                        f"Tried to add channel id {id} which already exists"
+                    )
+                id_map[id] = ws_id
+                reverse_id_map[ws_id] = id
+
+            asyncio.run_coroutine_threadsafe(handler(), loop)
+
+        def on_remove_channel(id: MiddlewareChannelId):
+            """
+            When the middleware notifies us a channel is removed, remove it from the WebSocket server.
+            """
+
+            async def handler():
+                logger.info("Removing channel %d", id)
+                ws_id = id_map.pop(id)
+                del reverse_id_map[ws_id]
+                await server.remove_channel(ws_id)
+
+            asyncio.run_coroutine_threadsafe(handler(), loop)
+
+        def on_message(id: MiddlewareChannelId, timestamp: int, payload: bytes):
+            """
+            When a message is received from the middleware, send it to clients via the WebSocket server.
+            """
+
+            async def handler():
+                logger.info("Sending message on channel %d %d", id, timestamp)
+                await server.send_message(id_map[id], timestamp, payload)
+
+            asyncio.run_coroutine_threadsafe(handler(), loop)
+
+        middleware.on_add_channel = on_add_channel
+        middleware.on_remove_channel = on_remove_channel
+        middleware.on_message = on_message
+
+        # Configure callbacks that the FoxgloveServer will call when its clients subscribe or
+        # unsubscribe from our channels.
+        class Listener(FoxgloveServerListener):
+            def on_subscribe(self, server: FoxgloveServer, channel_id: ChannelId):
+                """
+                When a WebSocket client first subscribes to a channel, create a subscription in the middleware.
+                """
+                logger.info("First client subscribed to %d", channel_id)
+                middleware.handle_subscribe_threadsafe(reverse_id_map[channel_id])
+
+            def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
+                """
+                When the last WebSocket client unsubscribes from a channel, remove the subscription in the middleware.
+                """
+                logger.info("Last client unsubscribed from %d", channel_id)
+                middleware.handle_unsubscribe_threadsafe(reverse_id_map[channel_id])
+
+        server.set_listener(Listener())
+
+        try:
+            # Start the middleware thread so it can run concurrently with the server.
+            # The middleware runs in its own, separate thread and calls our callbacks in that thread.
+            middleware.start()
+
+            # On the main thread, we simply sleep forever (until canceled). This looks like it does
+            # nothing, but it actually yields control to the asyncio event loop so that it can
+            # continue processing tasks, such as those created by our `run_coroutine_threadsafe()`
+            # calls above, as well as internal tasks created by the FoxgloveServer, such as when
+            # data is received on the WebSocket.
+            #
+            # An alternative implementation of this function could use `asyncio.to_thread(...)`
+            # instead of the `threading.Thread` class to run the middleware thread, in which case we
+            # wouldn't need this additional dummy future.
+            await asyncio.Future()
+        finally:
+            # To shut down cleanly, we notify the middleware that the program is shutting down, and
+            # then wait for the thread to terminate.
+            middleware.stop_threadsafe()
+            middleware.join()
+
+
+if __name__ == "__main__":
+    run_cancellable(main())

--- a/python/src/foxglove_websocket/examples/threaded_server/middleware.py
+++ b/python/src/foxglove_websocket/examples/threaded_server/middleware.py
@@ -1,0 +1,165 @@
+import json
+import random
+import threading
+import time
+import logging
+from typing import Callable, Dict, FrozenSet, NewType
+from foxglove_websocket.types import ChannelWithoutId
+
+
+logger = logging.getLogger("ExampleMiddlewareThread")
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setFormatter(
+    logging.Formatter("%(asctime)s: [%(levelname)s] <%(name)s> %(message)s")
+)
+logger.addHandler(handler)
+
+
+MiddlewareChannelId = NewType("MiddlewareChannelId", int)
+
+
+class ExampleMiddlewareThread(threading.Thread):
+    """
+    This class simulates a pub/sub middleware that provides callbacks in a separate thread. The
+    implementation details are not meant to be realistic, but just to simulate an environment where
+    channels are appearing and disappearing and messages are arriving at random times.
+
+    Calling code can provide callbacks which will be called from the middleware thread. To do so,
+    set the `on_add_channel`, `on_remove_channel`, and `on_message` properties.
+
+    This is a subclass of threading.Thread, so to launch the thread, use the `start()` method.
+    """
+
+    # The middleware will call these callbacks from the middleware thread.
+    on_add_channel: Callable[[MiddlewareChannelId, ChannelWithoutId], None]
+    on_remove_channel: Callable[[MiddlewareChannelId], None]
+    on_message: Callable[[MiddlewareChannelId, int, bytes], None]
+
+    # When the server subscribes to a channel, we'll get called in the server thread (the main
+    # thread). This lock is used to manage the set of subscribed channels safely across multiple
+    # threads.
+    #
+    # We use a frozenset to indicate that we won't mutate the data structure, we'll just replace it
+    # when subscriptions change. This allows the thread's main loop to briefly acquire the lock,
+    # grab a reference to the set of channels, and release the lock, knowing that the referenced set
+    # is safe to use from the thread, even if another thread happens to replace it.
+    _lock: threading.Lock
+    _subscribed_channels: FrozenSet[MiddlewareChannelId]
+
+    def __init__(self):
+        super().__init__()
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._stopped = False
+        self._subscribed_channels = frozenset()
+
+    def handle_subscribe_threadsafe(self, chan: MiddlewareChannelId):
+        """
+        Handle an added subscription from a WebSocket client. This method is thread-safe because it
+        uses a lock to access internal data structures. It will be called on the WebSocket server
+        thread.
+        """
+        with self._lock:
+            self._subscribed_channels = self._subscribed_channels | {chan}
+
+    def handle_unsubscribe_threadsafe(self, chan: MiddlewareChannelId):
+        """
+        Handle a removed subscription from a WebSocket client. This method is thread-safe because it
+        uses a lock to access internal data structures. It will be called on the WebSocket server
+        thread.
+        """
+        with self._lock:
+            self._subscribed_channels = self._subscribed_channels - {chan}
+
+    def stop_threadsafe(self):
+        """
+        Inform the thread that it should finish any active work and stop running. This method is
+        thread-safe because the threading.Event class is thread-safe.
+        """
+        self._stop_event.set()
+
+    def run(self):
+        """
+        This function provides the main entry point which will be executed in a new thread. It
+        periodically calls the on_add_channel, on_remove_channel, and on_message callbacks in the
+        middleware thread, simulating an active pub/sub graph.
+        """
+        logger.info("Middleware thread started")
+
+        # The lowest channel ID we'll use -- this illustrates mapping between native channels and
+        # FoxgloveServer channels.
+        start_id = MiddlewareChannelId(100)
+
+        # Last value published on each channel
+        active_channels: Dict[MiddlewareChannelId, int] = {}
+
+        def next_channel_id() -> MiddlewareChannelId:
+            """
+            Choose an available channel ID for creating a new channel.
+            """
+            i = start_id
+            while MiddlewareChannelId(i) in active_channels:
+                i += 1
+            return MiddlewareChannelId(i)
+
+        # Simulate some random events happening until we're asked to stop.
+        while not self._stop_event.wait(0.05):
+            # Take a reference to the current set of subscribed channels. Because this internal
+            # state may be accessed from multiple threads, we need to hold the lock while we access
+            # it. Once we release the lock, we know it's safe to continue using the reference during
+            # the rest of the loop because the set is never mutated by another thread -- it's only
+            # ever replaced with a completely new set.
+            with self._lock:
+                subscribed_channels = self._subscribed_channels
+
+            random_action = random.random()
+            if random_action < 0.05 or len(active_channels) == 0:
+                # Add a new channel
+                id = next_channel_id()
+                self.on_add_channel(
+                    id,
+                    {
+                        "topic": f"topic_{id}",
+                        "encoding": "json",
+                        "schemaName": f"ExampleMsg{id}",
+                        "schema": json.dumps(
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "msg": {"type": "string"},
+                                    "value": {"type": "number"},
+                                },
+                            }
+                        ),
+                    },
+                )
+                active_channels[id] = 0
+
+            elif random_action < 0.1:
+                # Remove a random channel
+                channel_id = random.choice(list(active_channels.keys()))
+                self.on_remove_channel(channel_id)
+                del active_channels[channel_id]
+                with self._lock:
+                    # Remove the channel from subscribed_channels so we don't try to publish a message to it.
+                    self._subscribed_channels = self._subscribed_channels - {channel_id}
+
+            elif subscribed_channels:
+                # Send a message on a random subscribed channel
+                chan = random.choice(list(subscribed_channels))
+                now = time.time_ns()
+                value = active_channels[chan]
+                active_channels[chan] += 1
+                self.on_message(
+                    chan,
+                    now,
+                    json.dumps({"msg": f"Hello channel {chan}", "value": value}).encode(
+                        "utf8"
+                    ),
+                )
+
+        # Clean up channels when shutting down
+        for id in active_channels:
+            self.on_remove_channel(id)
+        logger.info("Middleware thread finished")


### PR DESCRIPTION
**Public-Facing Changes**
Added a Python example script demonstrating how to use the `FoxgloveServer` in a multi-threaded program. Run the example with `python3 -m foxglove_websocket.examples.threaded_server`.