### PR TITLE
Python server: fix race condition with mutation of client state

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,3 +5,4 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 addopts = '-vv --color=yes'
 log_cli = true
+xfail_strict=true

--- a/python/src/foxglove_websocket/server/client_state.py
+++ b/python/src/foxglove_websocket/server/client_state.py
@@ -1,0 +1,81 @@
+from types import MappingProxyType
+from typing import Optional, Iterable
+from dataclasses import field
+from websockets.server import WebSocketServerProtocol
+from dataclasses import dataclass
+
+from ..types import ChannelId, SubscriptionId
+
+
+@dataclass
+class ClientState:
+    """
+    ClientState holds information about subscriptions from a given client, used by the server for
+    bookkeeping. The `subscriptions` and `subscriptions_by_channel` are immutable, which makes them
+    safe to use in concurrent (async) code without worrying that they will be mutated during
+    iteration.
+    """
+
+    connection: WebSocketServerProtocol
+    subscriptions: "MappingProxyType[SubscriptionId, ChannelId]" = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    subscriptions_by_channel: "MappingProxyType[ChannelId, Iterable[SubscriptionId]]" = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+
+    def remove_channel(self, removed_chan_id: ChannelId):
+        subs = self.subscriptions_by_channel.get(removed_chan_id)
+        if subs is not None:
+            self.subscriptions = MappingProxyType(
+                {
+                    sub: chan
+                    for sub, chan in self.subscriptions.items()
+                    if chan != removed_chan_id
+                }
+            )
+            self.subscriptions_by_channel = MappingProxyType(
+                {
+                    chan: subs
+                    for chan, subs in self.subscriptions_by_channel.items()
+                    if chan != removed_chan_id
+                }
+            )
+
+    def add_subscription(self, sub_id: SubscriptionId, chan_id: ChannelId):
+        self.subscriptions = MappingProxyType({**self.subscriptions, sub_id: chan_id})
+        self.subscriptions_by_channel = MappingProxyType(
+            {
+                **self.subscriptions_by_channel,
+                chan_id: {*self.subscriptions_by_channel.get(chan_id, ()), sub_id},
+            }
+        )
+
+    def remove_subscription(
+        self, removed_sub_id: SubscriptionId
+    ) -> Optional[ChannelId]:
+        chan_id = self.subscriptions.get(removed_sub_id)
+        if chan_id is None:
+            return None
+        self.subscriptions = MappingProxyType(
+            {
+                sub: chan
+                for sub, chan in self.subscriptions.items()
+                if sub != removed_sub_id
+            }
+        )
+        new_subscriptions_by_channel = {
+            chan: subs
+            for chan, subs in self.subscriptions_by_channel.items()
+            if chan != chan_id
+        }
+        new_subs = {
+            sub_id
+            for sub_id in self.subscriptions_by_channel.get(chan_id, ())
+            if sub_id != removed_sub_id
+        }
+        if new_subs:
+            new_subscriptions_by_channel[chan_id] = new_subs
+        self.subscriptions_by_channel = MappingProxyType(new_subscriptions_by_channel)
+
+        return chan_id

--- a/python/tests/test_client_state.py
+++ b/python/tests/test_client_state.py
@@ -1,0 +1,76 @@
+from typing import cast
+from foxglove_websocket.types import ChannelId, SubscriptionId
+from websockets.server import WebSocketServerProtocol
+from foxglove_websocket.server.client_state import ClientState
+
+
+def test_add_subscription():
+    state = ClientState(connection=cast(WebSocketServerProtocol, None))
+    assert state.subscriptions == {}
+    assert state.subscriptions_by_channel == {}
+
+    state.add_subscription(SubscriptionId(0), ChannelId(100))
+    assert state.subscriptions == {0: 100}
+    assert state.subscriptions_by_channel == {100: {0}}
+
+    state.add_subscription(SubscriptionId(1), ChannelId(101))
+    assert state.subscriptions == {0: 100, 1: 101}
+    assert state.subscriptions_by_channel == {100: {0}, 101: {1}}
+
+    state.add_subscription(SubscriptionId(2), ChannelId(101))
+    assert state.subscriptions == {0: 100, 1: 101, 2: 101}
+    assert state.subscriptions_by_channel == {100: {0}, 101: {1, 2}}
+
+
+def test_remove_subscription():
+    state = ClientState(connection=cast(WebSocketServerProtocol, None))
+    assert state.subscriptions == {}
+    assert state.subscriptions_by_channel == {}
+
+    state.add_subscription(SubscriptionId(0), ChannelId(100))
+    state.add_subscription(SubscriptionId(1), ChannelId(100))
+    state.add_subscription(SubscriptionId(2), ChannelId(100))
+    assert state.subscriptions == {0: 100, 1: 100, 2: 100}
+    assert state.subscriptions_by_channel == {100: {0, 1, 2}}
+
+    assert state.remove_subscription(SubscriptionId(99)) is None
+
+    assert state.remove_subscription(SubscriptionId(1)) == 100
+    assert state.subscriptions == {0: 100, 2: 100}
+    assert state.subscriptions_by_channel == {100: {0, 2}}
+
+    assert state.remove_subscription(SubscriptionId(0)) == 100
+    assert state.subscriptions == {2: 100}
+    assert state.subscriptions_by_channel == {100: {2}}
+
+    assert state.remove_subscription(SubscriptionId(2)) == 100
+    assert state.subscriptions == {}
+    assert state.subscriptions_by_channel == {}
+
+    assert state.remove_subscription(SubscriptionId(2)) is None
+
+
+def test_remove_channel():
+    state = ClientState(connection=cast(WebSocketServerProtocol, None))
+    assert state.subscriptions == {}
+    assert state.subscriptions_by_channel == {}
+
+    state.add_subscription(SubscriptionId(0), ChannelId(100))
+    state.add_subscription(SubscriptionId(1), ChannelId(100))
+    state.add_subscription(SubscriptionId(2), ChannelId(100))
+    state.add_subscription(SubscriptionId(3), ChannelId(101))
+
+    assert state.subscriptions == {0: 100, 1: 100, 2: 100, 3: 101}
+    assert state.subscriptions_by_channel == {100: {0, 1, 2}, 101: {3}}
+
+    state.remove_channel(ChannelId(999))
+    assert state.subscriptions == {0: 100, 1: 100, 2: 100, 3: 101}
+    assert state.subscriptions_by_channel == {100: {0, 1, 2}, 101: {3}}
+
+    state.remove_channel(ChannelId(100))
+    assert state.subscriptions == {3: 101}
+    assert state.subscriptions_by_channel == {101: {3}}
+
+    state.remove_channel(ChannelId(101))
+    assert state.subscriptions == {}
+    assert state.subscriptions_by_channel == {}

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -186,7 +186,6 @@ async def test_update_channels():
             }
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_unsubscribe_during_send():
     subscribed_event = asyncio.Event()


### PR DESCRIPTION
**Public-Facing Changes**
Fixed a crash in `send_message()` that could occur under load due to a race condition.

**Description**
Fixes https://github.com/foxglove/ws-protocol/issues/41. The race condition stemmed from mutation of `subscriptions_by_channel` during `await`. This would happen if channels were removed or if clients subscribed/unsubscribed while the server was waiting to send a message. To fix the race, the mutable data structures are replaced with immutable dicts (MappingProxyTypes), rather than copy them during each `send_message` call, since `send_message` is expected to be the most frequent API call.