### PR TITLE
Don't point dependabot at specific workspace packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,16 +10,6 @@ updates:
     schedule:
       interval: weekly
 
-  - package-ecosystem: npm
-    directory: "/typescript/ws-protocol"
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: "/typescript/ws-protocol-examples"
-    schedule:
-      interval: weekly
-
   - package-ecosystem: pip
     directory: "/python"
     schedule:


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Dependabot seems to handle upgrading sub-packages when it is pointed to the repo root, so we get duplicate PRs by also pointing it at the workspace packages.