### PR TITLE
Added publishing ability to FoxgloveClient

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -234,7 +234,9 @@ Informs the server that client channels are no longer available.
 {
   "op": "clientData",
   "topic": "foo",
-  "data": { "ExampleData": [1, 2] },
+  "data": {
+    "ExampleData": [1, 2]
+  },
   "timestamp": 123456789
 }
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,6 +33,9 @@
 
 - [Subscribe](#subscribe) (json)
 - [Unsubscribe](#unsubscribe) (json)
+- [Client Advertise](#client-advertise) (json)
+- [Client Unadvertise](#client-unadvertise) (json)
+- [Client Data](#client-data) (json)
 
 ## JSON messages
 
@@ -167,6 +170,72 @@ Informs the client that channels are no longer available.
 {
   "op": "unsubscribe",
   "subscriptionIds": [0, 1]
+}
+```
+
+### Client Advertise
+
+- Informs the server about available client channels.
+
+#### Fields
+
+- `op`: string `"clientAdvertise"`
+- `channels`: array of:
+  - `topic`: string
+  - `schemaName`: string
+
+#### Example
+
+```json
+{
+  "op": "clientAdvertise",
+  "channels": [
+    {
+      "topic": "foo",
+      "schemaName": "ExampleMsg"
+    }
+  ]
+}
+```
+
+### Client Unadvertise
+
+Informs the server that client channels are no longer available.
+
+#### Fields
+
+- `op`: string `"clientUnadvertise"`
+- `topics`: array of string, corresponding to previous Client Advertise
+
+#### Example
+
+```json
+{
+  "op": "clientUnadvertise",
+  "topics": ["foo"]
+}
+```
+
+### Client Data
+
+- A message sent from client to the server.
+- Client messages are in json encoding.
+
+#### Fields
+
+- `op`: string `"clientData"`
+- `topic`: string
+- `data`: key:value pairs of string keys and unknown values containing the client message data
+- `timestamp` (optional): number, client send timestamp (nanoseconds)
+
+#### Example
+
+```json
+{
+  "op": "clientData",
+  "topic": "foo",
+  "data": { "ExampleData": [1, 2] },
+  "timestamp": 123456789
 }
 ```
 

--- a/python/src/foxglove_websocket/examples/json_server.py
+++ b/python/src/foxglove_websocket/examples/json_server.py
@@ -6,6 +6,7 @@ from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
 from foxglove_websocket.types import ClientChannel, ChannelId
 from typing import Any, Dict, Optional
 
+
 async def main():
     class Listener(FoxgloveServerListener):
         def on_subscribe(self, server: FoxgloveServer, channel_id: ChannelId):
@@ -20,7 +21,12 @@ async def main():
         def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
             pass
 
-        def on_client_data(self, server: "FoxgloveServer", data: Dict[str, Any], timestamp: Optional[int] = None):
+        def on_client_data(
+            self,
+            server: "FoxgloveServer",
+            data: Dict[str, Any],
+            timestamp: Optional[int] = None,
+        ):
             pass
 
     async with FoxgloveServer("0.0.0.0", 8765, "example server") as server:

--- a/python/src/foxglove_websocket/examples/json_server.py
+++ b/python/src/foxglove_websocket/examples/json_server.py
@@ -3,8 +3,8 @@ import json
 import time
 from foxglove_websocket import run_cancellable
 from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
-from foxglove_websocket.types import ChannelId
-
+from foxglove_websocket.types import ClientChannel, ChannelId
+from typing import Any, Dict, Optional
 
 async def main():
     class Listener(FoxgloveServerListener):
@@ -13,6 +13,15 @@ async def main():
 
         def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             print("Last client unsubscribed from", channel_id)
+
+        def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
+            pass
+
+        def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
+            pass
+
+        def on_client_data(self, server: "FoxgloveServer", data: Dict[str, Any], timestamp: Optional[int] = None):
+            pass
 
     async with FoxgloveServer("0.0.0.0", 8765, "example server") as server:
         server.set_listener(Listener())

--- a/python/src/foxglove_websocket/examples/json_server.py
+++ b/python/src/foxglove_websocket/examples/json_server.py
@@ -2,32 +2,17 @@ import asyncio
 import json
 import time
 from foxglove_websocket import run_cancellable
-from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
-from foxglove_websocket.types import ClientChannel, ChannelId
-from typing import Any, Dict, Optional
+from foxglove_websocket.server import FoxgloveServer, SimpleFoxgloveServerListener
+from foxglove_websocket.types import ChannelId
 
 
 async def main():
-    class Listener(FoxgloveServerListener):
+    class Listener(SimpleFoxgloveServerListener):
         def on_subscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             print("First client subscribed to", channel_id)
 
         def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             print("Last client unsubscribed from", channel_id)
-
-        def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
-            pass
-
-        def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
-            pass
-
-        def on_client_data(
-            self,
-            server: "FoxgloveServer",
-            data: Dict[str, Any],
-            timestamp: Optional[int] = None,
-        ):
-            pass
 
     async with FoxgloveServer("0.0.0.0", 8765, "example server") as server:
         server.set_listener(Listener())

--- a/python/src/foxglove_websocket/examples/protobuf_server.py
+++ b/python/src/foxglove_websocket/examples/protobuf_server.py
@@ -21,7 +21,8 @@ import time
 from base64 import standard_b64encode
 from foxglove_websocket import run_cancellable
 from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
-from foxglove_websocket.types import ChannelId
+from foxglove_websocket.types import ClientChannel, ChannelId
+from typing import Any, Dict, Optional
 
 try:
     from foxglove_websocket.examples.proto import ExampleMsg_pb2
@@ -40,6 +41,15 @@ async def main():
 
         def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             print("Last client unsubscribed from", channel_id)
+
+        def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
+            pass
+
+        def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
+            pass
+
+        def on_client_data(self, server: "FoxgloveServer", data: Dict[str, Any], timestamp: Optional[int] = None):
+            pass
 
     # Load the FileDescriptorSet, which was generated via `protoc --descriptor_set_out`.
     with open(

--- a/python/src/foxglove_websocket/examples/protobuf_server.py
+++ b/python/src/foxglove_websocket/examples/protobuf_server.py
@@ -48,7 +48,12 @@ async def main():
         def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
             pass
 
-        def on_client_data(self, server: "FoxgloveServer", data: Dict[str, Any], timestamp: Optional[int] = None):
+        def on_client_data(
+            self,
+            server: "FoxgloveServer",
+            data: Dict[str, Any],
+            timestamp: Optional[int] = None,
+        ):
             pass
 
     # Load the FileDescriptorSet, which was generated via `protoc --descriptor_set_out`.

--- a/python/src/foxglove_websocket/examples/protobuf_server.py
+++ b/python/src/foxglove_websocket/examples/protobuf_server.py
@@ -20,9 +20,8 @@ import sys
 import time
 from base64 import standard_b64encode
 from foxglove_websocket import run_cancellable
-from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
-from foxglove_websocket.types import ClientChannel, ChannelId
-from typing import Any, Dict, Optional
+from foxglove_websocket.server import FoxgloveServer, SimpleFoxgloveServerListener
+from foxglove_websocket.types import ChannelId
 
 try:
     from foxglove_websocket.examples.proto import ExampleMsg_pb2
@@ -35,26 +34,12 @@ except ImportError as err:
 
 
 async def main():
-    class Listener(FoxgloveServerListener):
+    class Listener(SimpleFoxgloveServerListener):
         def on_subscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             print("First client subscribed to", channel_id)
 
         def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             print("Last client unsubscribed from", channel_id)
-
-        def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
-            pass
-
-        def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
-            pass
-
-        def on_client_data(
-            self,
-            server: "FoxgloveServer",
-            data: Dict[str, Any],
-            timestamp: Optional[int] = None,
-        ):
-            pass
 
     # Load the FileDescriptorSet, which was generated via `protoc --descriptor_set_out`.
     with open(

--- a/python/src/foxglove_websocket/examples/threaded_server/__main__.py
+++ b/python/src/foxglove_websocket/examples/threaded_server/__main__.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import concurrent.futures
-from typing import Any, Coroutine, Dict, Optional
+from typing import Any, Coroutine, Dict
 from foxglove_websocket import run_cancellable
 from foxglove_websocket.server import FoxgloveServer, SimpleFoxgloveServerListener
 from foxglove_websocket.types import ChannelId, ChannelWithoutId

--- a/python/src/foxglove_websocket/examples/threaded_server/__main__.py
+++ b/python/src/foxglove_websocket/examples/threaded_server/__main__.py
@@ -3,8 +3,8 @@ import logging
 import concurrent.futures
 from typing import Any, Coroutine, Dict, Optional
 from foxglove_websocket import run_cancellable
-from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
-from foxglove_websocket.types import ClientChannel, ChannelId, ChannelWithoutId
+from foxglove_websocket.server import FoxgloveServer, SimpleFoxgloveServerListener
+from foxglove_websocket.types import ChannelId, ChannelWithoutId
 
 from .middleware import ExampleMiddlewareThread, MiddlewareChannelId
 
@@ -118,7 +118,7 @@ async def main():
 
         # Configure callbacks that the FoxgloveServer will call when its clients subscribe or
         # unsubscribe from our channels.
-        class Listener(FoxgloveServerListener):
+        class Listener(SimpleFoxgloveServerListener):
             def on_subscribe(self, server: FoxgloveServer, channel_id: ChannelId):
                 """
                 When a WebSocket client first subscribes to a channel, create a subscription in the middleware.
@@ -132,22 +132,6 @@ async def main():
                 """
                 logger.info("Last client unsubscribed from %d", channel_id)
                 middleware.handle_unsubscribe_threadsafe(reverse_id_map[channel_id])
-
-            def on_client_advertise(
-                self, server: "FoxgloveServer", channel: ClientChannel
-            ):
-                pass
-
-            def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
-                pass
-
-            def on_client_data(
-                self,
-                server: "FoxgloveServer",
-                data: Dict[str, Any],
-                timestamp: Optional[int] = None,
-            ):
-                pass
 
         server.set_listener(Listener())
 

--- a/python/src/foxglove_websocket/examples/threaded_server/__main__.py
+++ b/python/src/foxglove_websocket/examples/threaded_server/__main__.py
@@ -1,10 +1,10 @@
 import asyncio
 import logging
 import concurrent.futures
-from typing import Any, Coroutine, Dict
+from typing import Any, Coroutine, Dict, Optional
 from foxglove_websocket import run_cancellable
 from foxglove_websocket.server import FoxgloveServer, FoxgloveServerListener
-from foxglove_websocket.types import ChannelId, ChannelWithoutId
+from foxglove_websocket.types import ClientChannel, ChannelId, ChannelWithoutId
 
 from .middleware import ExampleMiddlewareThread, MiddlewareChannelId
 
@@ -132,6 +132,22 @@ async def main():
                 """
                 logger.info("Last client unsubscribed from %d", channel_id)
                 middleware.handle_unsubscribe_threadsafe(reverse_id_map[channel_id])
+
+            def on_client_advertise(
+                self, server: "FoxgloveServer", channel: ClientChannel
+            ):
+                pass
+
+            def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
+                pass
+
+            def on_client_data(
+                self,
+                server: "FoxgloveServer",
+                data: Dict[str, Any],
+                timestamp: Optional[int] = None,
+            ):
+                pass
 
         server.set_listener(Listener())
 

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -65,11 +65,17 @@ class FoxgloveServerListener(ABC):
         ...
 
     @abstractmethod
-    def on_client_data(self, server: "FoxgloveServer", data: Dict[str, Any], timestamp: Optional[int] = None):
+    def on_client_data(
+        self,
+        server: "FoxgloveServer",
+        data: Dict[str, Any],
+        timestamp: Optional[int] = None,
+    ):
         """
         Called when server receives client data.
         """
         ...
+
 
 class FoxgloveServer:
     _clients: Tuple[ClientState, ...]
@@ -357,6 +363,8 @@ class FoxgloveServer:
                     self._listener.on_client_unadvertise(self, topic)
         elif message["op"] == "clientData":
             if self._listener:
-                self._listener.on_client_data(self, message["data"], message.get("timestamp"))
+                self._listener.on_client_data(
+                    self, message["data"], message.get("timestamp")
+                )
         else:
             raise ValueError(f"Unrecognized client opcode: {message['op']}")

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -77,6 +77,22 @@ class FoxgloveServerListener(ABC):
         ...
 
 
+class SimpleFoxgloveServerListener(FoxgloveServerListener):
+    def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
+        pass
+
+    def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
+        pass
+
+    def on_client_data(
+        self,
+        server: "FoxgloveServer",
+        data: Dict[str, Any],
+        timestamp: Optional[int] = None,
+    ):
+        pass
+
+
 class FoxgloveServer:
     _clients: Tuple[ClientState, ...]
     _channels: Dict[ChannelId, Channel]

--- a/python/src/foxglove_websocket/types.py
+++ b/python/src/foxglove_websocket/types.py
@@ -41,7 +41,10 @@ class ClientData(TypedDict):
     data: Dict[str, Any]
     timestamp: Optional[int]
 
-ClientMessage = Union[Subscribe, Unsubscribe, ClientAdvertise, ClientUnadvertise, ClientData]
+
+ClientMessage = Union[
+    Subscribe, Unsubscribe, ClientAdvertise, ClientUnadvertise, ClientData
+]
 
 
 class BinaryOpcode(IntEnum):
@@ -88,6 +91,7 @@ class Unadvertise(TypedDict):
 
 
 ServerMessage = Union[ServerInfo, StatusMessage, Advertise, Unadvertise]
+
 
 class ServerCapabilities(Enum):
     receiveClientData = "receiveClientData"

--- a/python/src/foxglove_websocket/types.py
+++ b/python/src/foxglove_websocket/types.py
@@ -1,5 +1,5 @@
-from typing import List, Literal, NewType, TypedDict, Union
-from enum import IntEnum
+from typing import Any, Dict, List, Literal, NewType, Optional, TypedDict, Union
+from enum import Enum, IntEnum
 
 ChannelId = NewType("ChannelId", int)
 SubscriptionId = NewType("SubscriptionId", int)
@@ -20,7 +20,28 @@ class Unsubscribe(TypedDict):
     subscriptionIds: List[SubscriptionId]
 
 
-ClientMessage = Union[Subscribe, Unsubscribe]
+class ClientChannel(TypedDict):
+    topic: str
+    schemaName: str
+
+
+class ClientAdvertise(TypedDict):
+    op: Literal["clientAdvertise"]
+    channels: List[ClientChannel]
+
+
+class ClientUnadvertise(TypedDict):
+    op: Literal["clientUnadvertise"]
+    topics: List[str]
+
+
+class ClientData(TypedDict):
+    op: Literal["clientData"]
+    topic: str
+    data: Dict[str, Any]
+    timestamp: Optional[int]
+
+ClientMessage = Union[Subscribe, Unsubscribe, ClientAdvertise, ClientUnadvertise, ClientData]
 
 
 class BinaryOpcode(IntEnum):
@@ -67,3 +88,6 @@ class Unadvertise(TypedDict):
 
 
 ServerMessage = Union[ServerInfo, StatusMessage, Advertise, Unadvertise]
+
+class ServerCapabilities(Enum):
+    receiveClientData = "receiveClientData"

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -3,7 +3,7 @@ import json
 import logging
 import pytest
 from socket import AddressFamily
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple, Optional
 from websockets.client import connect
 from websockets.server import WebSocketServer
 
@@ -12,7 +12,12 @@ from foxglove_websocket.server import (
     FoxgloveServerListener,
     MessageDataHeader,
 )
-from foxglove_websocket.types import BinaryOpcode, ChannelId, ChannelWithoutId
+from foxglove_websocket.types import (
+    BinaryOpcode,
+    ChannelId,
+    ChannelWithoutId,
+    ClientChannel,
+)
 
 
 def get_server_url(server: WebSocketServer):
@@ -102,6 +107,20 @@ async def test_listener_callbacks():
 
         def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             listener_calls.append(("unsubscribe", channel_id))
+
+        def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
+            pass
+
+        def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
+            pass
+
+        def on_client_data(
+            self,
+            server: "FoxgloveServer",
+            data: Dict[str, Any],
+            timestamp: Optional[int] = None,
+        ):
+            pass
 
     async with FoxgloveServer("localhost", None, "test server") as server:
         server.set_listener(Listener())
@@ -197,6 +216,20 @@ async def test_unsubscribe_during_send():
 
         def on_unsubscribe(self, server: FoxgloveServer, channel_id: ChannelId):
             unsubscribed_event.set()
+
+        def on_client_advertise(self, server: "FoxgloveServer", channel: ClientChannel):
+            pass
+
+        def on_client_unadvertise(self, server: "FoxgloveServer", topic: str):
+            pass
+
+        def on_client_data(
+            self,
+            server: "FoxgloveServer",
+            data: Dict[str, Any],
+            timestamp: Optional[int] = None,
+        ):
+            pass
 
     async with FoxgloveServer("localhost", None, "test server") as server:
         server.set_listener(Listener())

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -29,6 +29,8 @@ export default class FoxgloveClient {
   private emitter = new EventEmitter<EventTypes>();
   private ws: IWebSocket;
   private nextSubscriptionId = 0;
+  private nextChannelId = 0;
+  private channelsById = new Map<ChannelId, Channel>();
 
   constructor({ ws }: { ws: IWebSocket }) {
     this.ws = ws;
@@ -108,6 +110,57 @@ export default class FoxgloveClient {
     const subscriptions = [{ id, channelId }];
     this.send({ op: "subscribe", subscriptions });
     return id;
+  }
+
+  /**
+   * Advertise a new channel and inform any connected servers.
+   * @returns The id of the new channel
+   */
+  addChannel(channel: Omit<Channel, "id">): ChannelId {
+    const newId = ++this.nextChannelId;
+    const newChannel: Channel = { ...channel, id: newId };
+    this.channelsById.set(newId, newChannel);
+    this.send({ op: "advertise", channels: [newChannel] });
+    return newId;
+  }
+
+  /**
+   * Remove a previously advertised channel and inform any connected servers.
+   */
+  removeChannel(channelId: ChannelId): void {
+    if (!this.channelsById.delete(channelId)) {
+      throw new Error(`Channel ${channelId} does not exist`);
+    }
+    this.send({ op: "unadvertise", channelIds: [channelId] });
+  }
+
+  sendMessageData(
+    subscriptionId: SubscriptionId,
+    timestamp: bigint,
+    payload: BufferSource,
+  ): void {
+    const header = new DataView(new ArrayBuffer(1 + 4 + 8));
+    header.setUint8(0, BinaryOpcode.MESSAGE_DATA);
+    header.setUint32(1, subscriptionId, true);
+    header.setBigUint64(5, timestamp, true);
+
+    // attempt to detect support for {fin: false}
+    if (this.ws.send.length > 1) {
+      this.ws.send(header.buffer, { fin: false });
+      this.ws.send(payload, { fin: true });
+    } else if (typeof Blob === "function") {
+      this.ws.send(new Blob([header.buffer, payload]));
+    } else {
+      const buffer = new Uint8Array(header.buffer.byteLength + payload.byteLength);
+      buffer.set(new Uint8Array(header.buffer), 0);
+      buffer.set(
+        ArrayBuffer.isView(payload)
+          ? new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength)
+          : new Uint8Array(payload),
+        header.buffer.byteLength,
+      );
+      this.ws.send(buffer);
+    }
   }
 
   unsubscribe(subscriptionId: SubscriptionId): void {

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -134,11 +134,7 @@ export default class FoxgloveClient {
     this.send({ op: "unadvertise", channelIds: [channelId] });
   }
 
-  sendMessageData(
-    subscriptionId: SubscriptionId,
-    timestamp: bigint,
-    payload: BufferSource,
-  ): void {
+  sendMessageData(subscriptionId: SubscriptionId, timestamp: bigint, payload: BufferSource): void {
     const header = new DataView(new ArrayBuffer(1 + 4 + 8));
     header.setUint8(0, BinaryOpcode.MESSAGE_DATA);
     header.setUint32(1, subscriptionId, true);

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -125,8 +125,8 @@ export default class FoxgloveClient {
     this.send({ op: "clientUnadvertise", topics: [topic] });
   }
 
-  sendData(topic: string, timestamp: number, msg: Record<string, unknown>): void {
-    this.send({ op: "clientData", topic, timestamp, data: msg })
+  sendData(topic: string, msg: Record<string, unknown>, timestamp?: number): void {
+    this.send({ op: "clientData", topic, data: msg, ...(timestamp != undefined) && {timestamp} })
   }
 
   unsubscribe(subscriptionId: SubscriptionId): void {

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -126,7 +126,7 @@ export default class FoxgloveClient {
   }
 
   sendData(topic: string, msg: Record<string, unknown>, timestamp?: number): void {
-    this.send({ op: "clientData", topic, data: msg, ...(timestamp != undefined) && {timestamp} })
+    this.send({ op: "clientData", topic, data: msg, ...(timestamp != undefined && { timestamp }) });
   }
 
   unsubscribe(subscriptionId: SubscriptionId): void {

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -16,7 +16,25 @@ export type Channel = {
   schema: string;
 };
 export type SubscriptionId = number;
+export type ClientChannel = {
+  topic: string;
+  schemaName: string;
+};
 
+export type ClientAdvertise = {
+  op: "clientAdvertise";
+  channels: ClientChannel[];
+};
+export type ClientUnadvertise = {
+  op: "clientUnadvertise";
+  topics: string[];
+};
+export type ClientData = {
+  op: "clientData";
+  topic: string;
+  data: Record<string, unknown>;
+  timestamp?: number;
+};
 export type Subscribe = {
   op: "subscribe";
   subscriptions: Array<{
@@ -28,8 +46,7 @@ export type Unsubscribe = {
   op: "unsubscribe";
   subscriptionIds: SubscriptionId[];
 };
-
-export type ClientMessage = Subscribe | Unsubscribe | Advertise | Unadvertise | MessageData;
+export type ClientMessage = Subscribe | Unsubscribe | ClientAdvertise | ClientUnadvertise | ClientData;
 
 export type ServerInfo = {
   op: "serverInfo";
@@ -57,6 +74,11 @@ export type MessageData = {
 };
 
 export type ServerMessage = ServerInfo | StatusMessage | Advertise | Unadvertise | MessageData;
+
+export const ServerCapabilities: Record<string, string> = {
+  // Server can receive client data.
+  receiveClientData: "receiveClientData",
+};
 
 /**
  * Abstraction that supports both browser and Node WebSocket clients.

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -46,7 +46,12 @@ export type Unsubscribe = {
   op: "unsubscribe";
   subscriptionIds: SubscriptionId[];
 };
-export type ClientMessage = Subscribe | Unsubscribe | ClientAdvertise | ClientUnadvertise | ClientData;
+export type ClientMessage =
+  | Subscribe
+  | Unsubscribe
+  | ClientAdvertise
+  | ClientUnadvertise
+  | ClientData;
 
 export type ServerInfo = {
   op: "serverInfo";
@@ -75,7 +80,7 @@ export type MessageData = {
 
 export type ServerMessage = ServerInfo | StatusMessage | Advertise | Unadvertise | MessageData;
 
-export const ServerCapabilities: Record<string, string> = {
+export const ServerCapabilities = {
   // Server can receive client data.
   receiveClientData: "receiveClientData",
 };

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -29,7 +29,7 @@ export type Unsubscribe = {
   subscriptionIds: SubscriptionId[];
 };
 
-export type ClientMessage = Subscribe | Unsubscribe;
+export type ClientMessage = Subscribe | Unsubscribe | Advertise | Unadvertise | MessageData;
 
 export type ServerInfo = {
   op: "serverInfo";


### PR DESCRIPTION
* Added publishing ability to FoxgloveClient: `advertise()`, `unadvertise()`, `sendData()`
* Updated python server examples to handle messages from client

**Public-Facing Changes**
Ability to publish from client (Foxglove studio) to server (e.g. robot) through the Publish/Teleop/etc panels.

**Demo Steps**
See attached video for final result:

https://user-images.githubusercontent.com/33838550/170392225-3d9fc846-f814-4a31-b45d-e7407e2c2293.mp4


1. Pull corresponding branch from [foxglove/studio PR](https://github.com/foxglove/studio/pull/3431) 
2. Launch foxglove client: `yarn install && yarn:serve`
3. Pull this branch (foxglove/ws-protocol) and launch any of the python servers, e.g.: `python python/src/foxglove_websocket/examples/json_server.py` 
4. In foxglove client, publish data through Teleop/Publish panels.
5. The active python server console should print the messages being received.

**Description**
* Should be merged before https://github.com/foxglove/studio/pull/3431
* Addresses https://github.com/foxglove/ws-protocol/issues/38


**Future TODOs**
- update c++/typescript server examples.