### PR TITLE
Don't run TestPyPI CI step on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN }}


### PR DESCRIPTION
**Public-facing changes**
None

**Description**
Skip running TestPyPI CI step on PRs from forks, since the auth token will not be available.
Same fix as https://github.com/foxglove/mcap/pull/358