### PR TITLE
exclude _pb2.py generated files from pyright

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,3 +12,6 @@ exclude = '_pb2\.py$'
 color = true
 diff = true
 verbose = true
+
+[tool.pyright]
+exclude = ['**/*_pb2.py']


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
CI started failing recently on this generated file.