### PR TITLE
skip TestPyPI for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ !github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
+        if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]' }}
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN }}


### PR DESCRIPTION
Skip TestPyPI on dependabot PRs, since dependabot does not have access to the TestPyPI secret