### PR TITLE
Extend spec with ability to send data from client to server.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -35,7 +35,7 @@
 - [Unsubscribe](#unsubscribe) (json)
 - [Client Advertise](#client-advertise) (json)
 - [Client Unadvertise](#client-unadvertise) (json)
-- [Client Message Data](#client-message-data) (json)
+- [Client Message Data](#client-message-data) (binary)
 
 ## JSON messages
 
@@ -223,32 +223,15 @@ Informs the client that channels are no longer available.
 
 ### Client Publish
 
-- Sends a JSON message from the client to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
+- Sends a binary websocket message that contains the JSON encoded messsage from the client to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
 
 #### Fields
 
-- `op`: string `"publish"`
-- `channelId`: number. Channel ID corresponding to previous [Client Advertise](#client-advertise)
-- `data`: object. JSON object
-
-#### Example
-
-```json
-{
-  "op": "publish",
-  "channelId": 1,
-  "data": {
-    "header": {
-      "frame_id": "/map"
-    },
-    "point": {
-      "x": 1.0,
-      "y": 2.0,
-      "z": 0.0
-    }
-  }
-}
-```
+| Bytes           | Type    | Description                     |
+| --------------- | ------- | ------------------------------- |
+| 1               | opcode  | 0x01                            |
+| 4               | uint32  | channel id                      |
+| remaining bytes | uint8[] | message payload (JSON enconded) |
 
 ## Binary messages
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -184,7 +184,7 @@ Informs the client that channels are no longer available.
 - `channels`: array of:
   - `id`: number chosen by the client. The client may reuse ids that have previously been unadvertised.
   - `topic`: string
-  - `encoding`: string, must be `"json"`
+  - `encoding`: string
   - `schemaName`: string
 
 #### Example
@@ -196,7 +196,7 @@ Informs the client that channels are no longer available.
     {
       "id": 1,
       "topic": "foo",
-      "encoding": "json",
+      "encoding": "protobuf",
       "schemaName": "ExampleMsg"
     }
   ]
@@ -223,15 +223,17 @@ Informs the client that channels are no longer available.
 
 ### Client Publish
 
-- Sends a binary websocket message that contains the JSON encoded messsage from the client to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
+- Sends a binary websocket message containing the raw messsage payload to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
 
-#### Fields
+#### Message Data
 
-| Bytes           | Type    | Description                     |
-| --------------- | ------- | ------------------------------- |
-| 1               | opcode  | 0x01                            |
-| 4               | uint32  | channel id                      |
-| remaining bytes | uint8[] | message payload (JSON enconded) |
+- Provides a raw message payload, encoded as advertised in the [Client Advertise](#client-advertise) operation.
+
+| Bytes           | Type    | Description     |
+| --------------- | ------- | --------------- |
+| 1               | opcode  | 0x01            |
+| 4               | uint32  | channel id      |
+| remaining bytes | uint8[] | message payload |
 
 ## Binary messages
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -221,7 +221,7 @@ Informs the client that channels are no longer available.
 }
 ```
 
-### Client Message Data
+### Client Publish
 
 - Sends a JSON message from the client to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,6 +33,9 @@
 
 - [Subscribe](#subscribe) (json)
 - [Unsubscribe](#unsubscribe) (json)
+- [Client Advertise](#client-advertise) (json)
+- [Client Unadvertise](#client-unadvertise) (json)
+- [Client Message Data](#client-message-data) (json)
 
 ## JSON messages
 
@@ -167,6 +170,82 @@ Informs the client that channels are no longer available.
 {
   "op": "unsubscribe",
   "subscriptionIds": [0, 1]
+}
+```
+
+### Client Advertise
+
+- Informs the server about available client channels.
+
+#### Fields
+
+- `op`: string `"client_advertise"`
+- `channels`: array of:
+  - `id`: number chosen by the client. The client may not reuse ids across multiple advertised channels.
+  - `topic`: string
+  - `encoding`: string `"json"`
+  - `schemaName`: string
+
+#### Example
+
+```json
+{
+  "op": "client_advertise",
+  "channels": [
+    {
+      "id": 1,
+      "topic": "foo",
+      "encoding": "json",
+      "schemaName": "ExampleMsg"
+    }
+  ]
+}
+```
+
+### Client Unadvertise
+
+- Informs the server that client channels are no longer available.
+
+#### Fields
+
+- `op`: string `"client_unadvertise"`
+- `channelIds`: array of number, corresponding to previous [Client Advertise](#client-advertise)
+
+#### Example
+
+```json
+{
+  "op": "client_unadvertise",
+  "channelIds": [1, 2]
+}
+```
+
+### Client Message Data
+
+- Sends a JSON message from the client to the server.
+
+#### Fields
+
+- `op`: string `"client_message_data"`
+- `channelId`: number. Channel ID corresponding to previous [Client Advertise](#client-advertise)
+- `data`: object. JSON object
+
+#### Example
+
+```json
+{
+  "op": "client_message_data",
+  "channelId": 1,
+  "data": {
+    "header": {
+      "frame_id": "/map"
+    },
+    "point": {
+      "x": 1.0,
+      "y": 2.0,
+      "z": 0.0
+    }
+  }
 }
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -176,13 +176,13 @@ Informs the client that channels are no longer available.
 
 ### Client Advertise
 
-- Informs the server about available client channels. Note that hhe client is only allowed to advertise channels if the server previously declared that it has the `clientPublish` [capability](#server-info).
+- Informs the server about available client channels. Note that the client is only allowed to advertise channels if the server previously declared that it has the `clientPublish` [capability](#server-info).
 
 #### Fields
 
 - `op`: string `"advertise"`
 - `channels`: array of:
-  - `id`: number chosen by the client. The client may not reuse ids across multiple advertised channels.
+  - `id`: number chosen by the client. The client may reuse ids that have previously been unadvertised.
   - `topic`: string
   - `encoding`: string, must be `"json"`
   - `schemaName`: string
@@ -205,7 +205,7 @@ Informs the client that channels are no longer available.
 
 ### Client Unadvertise
 
-- Informs the server that client channels are no longer available.
+- Informs the server that client channels are no longer available. Note that the client is only allowed to unadvertise channels if the server previously declared that it has the `clientPublish` [capability](#server-info).
 
 #### Fields
 
@@ -223,7 +223,7 @@ Informs the client that channels are no longer available.
 
 ### Client Message Data
 
-- Sends a JSON message from the client to the server.
+- Sends a JSON message from the client to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
 
 #### Fields
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -49,7 +49,8 @@ Each JSON message must be an object containing a field called `op` which identif
 
 - `op`: string `"serverInfo"`
 - `name`: free-form information about the server which the client may optionally display or use for debugging purposes
-- `capabilities`: array of strings (reserved for future expansions to the spec)
+- `capabilities`: array of strings, informing the client about which optional features are supported
+  - `clientPublish`: Allow clients to advertise channels to send data messages to the server
 
 #### Example
 
@@ -57,7 +58,7 @@ Each JSON message must be an object containing a field called `op` which identif
 {
   "op": "serverInfo",
   "name": "example server",
-  "capabilities": []
+  "capabilities": ["clientPublish"]
 }
 ```
 
@@ -175,22 +176,22 @@ Informs the client that channels are no longer available.
 
 ### Client Advertise
 
-- Informs the server about available client channels.
+- Informs the server about available client channels. Note that hhe client is only allowed to advertise channels if the server previously declared that it has the `clientPublish` [capability](#server-info).
 
 #### Fields
 
-- `op`: string `"client_advertise"`
+- `op`: string `"advertise"`
 - `channels`: array of:
   - `id`: number chosen by the client. The client may not reuse ids across multiple advertised channels.
   - `topic`: string
-  - `encoding`: string `"json"`
+  - `encoding`: string, must be `"json"`
   - `schemaName`: string
 
 #### Example
 
 ```json
 {
-  "op": "client_advertise",
+  "op": "advertise",
   "channels": [
     {
       "id": 1,
@@ -208,14 +209,14 @@ Informs the client that channels are no longer available.
 
 #### Fields
 
-- `op`: string `"client_unadvertise"`
+- `op`: string `"unadvertise"`
 - `channelIds`: array of number, corresponding to previous [Client Advertise](#client-advertise)
 
 #### Example
 
 ```json
 {
-  "op": "client_unadvertise",
+  "op": "unadvertise",
   "channelIds": [1, 2]
 }
 ```
@@ -226,7 +227,7 @@ Informs the client that channels are no longer available.
 
 #### Fields
 
-- `op`: string `"client_message_data"`
+- `op`: string `"publish"`
 - `channelId`: number. Channel ID corresponding to previous [Client Advertise](#client-advertise)
 - `data`: object. JSON object
 
@@ -234,7 +235,7 @@ Informs the client that channels are no longer available.
 
 ```json
 {
-  "op": "client_message_data",
+  "op": "publish",
   "channelId": 1,
   "data": {
     "header": {


### PR DESCRIPTION
**Public-Facing Changes**
Extend the spec with ability to send data from client to server.


**Description**
This PR adds 3 new operations to the spec to allow sending data from the client to the server. Once we have agreed on the spec, I will update the example server implementation accordingly.

Partially fixes #38 
Partially supersedes #158 
