### PR TITLE
python readme: string literal for [examples]

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ $ pip install foxglove-websocket
 This package includes example servers demonstrating how to use JSON and Protobuf data. To install additional dependencies required for the examples, run:
 
 ```
-$ pip install foxglove-websocket[examples]
+$ pip install 'foxglove-websocket[examples]'
 ```
 
 Run a simple example server that publishes messages on a single `example_msg` topic:


### PR DESCRIPTION
zsh (the default shell on MacOS) needs backslashes to be escaped or the argument to be quoted, see e.g.: https://stackoverflow.com/a/30539963/5087436
