### PR TITLE
Add Node max version

### DIFF
--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -19,7 +19,7 @@
     "email": "support@foxglove.dev"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 14 <18"
   },
   "homepage": "https://foxglove.dev/",
   "module": "dist/esm/ws-protocol-examples/src/index.js",

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol-examples",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Foxglove WebSocket protocol examples",
   "keywords": [
     "foxglove",


### PR DESCRIPTION
**Public-Facing Changes**
Added Node.js max version to `npx @foxglove/ws-protocol-examples`.

**Description**
Node 18 is not currently supported due to https://github.com/cruise-automation/wasm-lz4/issues/8 & https://github.com/foxglove/wasm-bz2/issues/4