### PR TITLE
publish-client example: Make sure connection is established

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/publish-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/publish-client.ts
@@ -25,16 +25,18 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
     throw error;
   });
 
-  client.on("open", async () => {
-    if (args.encoding === "json") {
-      await sendJsonMessages(client);
-    } else if (args.encoding === "ros1") {
-      await sendRos1Messages(client);
-    } else if (args.encoding === "cdr") {
-      await sendRos2Messages(client);
-    }
+  client.on("open", () => {
+    (async () => {
+      if (args.encoding === "json") {
+        await sendJsonMessages(client);
+      } else if (args.encoding === "ros1") {
+        await sendRos1Messages(client);
+      } else if (args.encoding === "cdr") {
+        await sendRos2Messages(client);
+      }
 
-    client.close();
+      client.close();
+    })();
   });
 }
 

--- a/typescript/ws-protocol-examples/src/examples/publish-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/publish-client.ts
@@ -25,15 +25,17 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
     throw error;
   });
 
-  if (args.encoding === "json") {
-    await sendJsonMessages(client);
-  } else if (args.encoding === "ros1") {
-    await sendRos1Messages(client);
-  } else if (args.encoding === "cdr") {
-    await sendRos2Messages(client);
-  }
+  client.on("open", async () => {
+    if (args.encoding === "json") {
+      await sendJsonMessages(client);
+    } else if (args.encoding === "ros1") {
+      await sendRos1Messages(client);
+    } else if (args.encoding === "cdr") {
+      await sendRos2Messages(client);
+    }
 
-  client.close();
+    client.close();
+  });
 }
 
 async function sendJsonMessages(client: FoxgloveClient) {

--- a/typescript/ws-protocol-examples/src/examples/publish-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/publish-client.ts
@@ -36,7 +36,7 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
       }
 
       client.close();
-    })();
+    })().catch(console.error);
   });
 }
 


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
This patch fixes a small bug in the `publish-client` example. We first have to wait until the websocket connection is established before we can publish messages over it
