### PR TITLE
Build passing on win and remove the C++20 feature

### DIFF
--- a/cpp/foxglove-websocket/include/foxglove/websocket/server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server.hpp
@@ -14,6 +14,11 @@
 #include <unordered_set>
 #include <vector>
 
+// Windows badly defines a lot of stuff we'll never use. Undefine it.
+#ifdef _WIN32
+#undef ERROR  // override (really stupid) wingdi.h standard definition
+#endif
+
 namespace foxglove::websocket {
 
 using json = nlohmann::json;
@@ -174,10 +179,7 @@ inline void Server::handleConnectionOpened(ConnHandle hdl) {
   _server.get_alog().write(
     websocketpp::log::alevel::app,
     "Client " + con->get_remote_endpoint() + " connected via " + con->get_resource());
-  _clients.emplace(hdl, ClientInfo{
-                          .name = con->get_remote_endpoint(),
-                          .handle = hdl,
-                        });
+  _clients.emplace(hdl, ClientInfo{con->get_remote_endpoint(), hdl});
 
   con->send(json({
                    {"op", "serverInfo"},


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->

None

**Description**
<!-- describe what has changed, and motivation behind those changes -->

- `StatusLevel::ERROR` conflicts with `winsock2.h` included by `websocketpp\common\network.hpp`, we should undef the marco in `_WIN32`
-  designated initializers is C++20 feature, our [conanfile](https://github.com/foxglove/ws-protocol/blob/main/cpp/foxglove-websocket/conanfile.py#L18) just require C++17.

<!-- link relevant GitHub issues -->

#35