### PR TITLE
Extend spec with parameter support

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -341,11 +341,11 @@ Set one or more parameters. Only supported if the server previously declared tha
 
 Subscribe to parameter updates. Only supported if the server previously declared that it has the `parameterSubscribe` [capability](#server-info).
 
-Note that parameters can be subscribed at most once. Hence, this operation will ignore parameters that are already subscribed. Use [unsubscribeParameterUdpates](#unsubscribe-parameter-update) to unsubscribe from existing parameter subscriptions.
+Sending `subscribeParameterUpdates` multiple times will append the list of parameter subscriptions, not replace them. Note that parameters can be subscribed at most once. Hence, this operation will ignore parameters that are already subscribed. Use [unsubscribeParameterUdpates](#unsubscribe-parameter-update) to unsubscribe from existing parameter subscriptions.
 
 #### Fields
 
-- `op`: string `"subscribeParameterUdpates"`
+- `op`: string `"subscribeParameterUpdates"`
 - `parameterNames`: string[], leave empty to subscribe to all currently known parameters
 
 #### Example
@@ -368,7 +368,7 @@ Unsubscribe from parameter updates. Only supported if the server previously decl
 
 #### Fields
 
-- `op`: string `"unsubscribeParameterUdpates"`
+- `op`: string `"unsubscribeParameterUpdates"`
 - `parameterNames`: string[], leave empty to unsubscribe from all parameter updates
 
 #### Example

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -323,7 +323,7 @@ Set one or more parameters. Only supported if the server previously declared tha
 
 Subscribe to parameter updates. Only supported if the server previously declared that it has the `parametersSubscribe` [capability](#server-info).
 
-Sending `subscribeParameterUpdates` multiple times will append the list of parameter subscriptions, not replace them. Note that parameters can be subscribed at most once. Hence, this operation will ignore parameters that are already subscribed. Use [unsubscribeParameterUdpates](#unsubscribe-parameter-update) to unsubscribe from existing parameter subscriptions.
+Sending `subscribeParameterUpdates` multiple times will append the list of parameter subscriptions, not replace them. Note that parameters can be subscribed at most once. Hence, this operation will ignore parameters that are already subscribed. Use [unsubscribeParameterUpdates](#unsubscribe-parameter-update) to unsubscribe from existing parameter subscriptions.
 
 #### Fields
 
@@ -334,7 +334,7 @@ Sending `subscribeParameterUpdates` multiple times will append the list of param
 
 ```json
 {
-  "op": "subscribeParameterUdpates",
+  "op": "subscribeParameterUpdates",
   "parameterNames": [
     "/int_param",
     "/float_param",
@@ -357,7 +357,7 @@ Unsubscribe from parameter updates. Only supported if the server previously decl
 
 ```json
 {
-  "op": "unsubscribeParameterUdpates",
+  "op": "unsubscribeParameterUpdates",
   "parameterNames": [
     "/int_param",
     "/float_param",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -143,18 +143,17 @@ Informs the client that channels are no longer available.
 
 Informs the client about parameters. Only supported if the server declares the `parameters` [capability](#server-info).
 
-The server may send this message
-
-- at arbitrary points in time
-- as a response to the client's [Get Parameters request](#get-parameters)
-- when parameters have changed which were [subscribed](#subscribe-parameter-update) by the client
-
 #### Fields
 
 - `op`: string `"parameterValues"`
 - `parameters`: array of:
   - `name`: string, name of the parameter
   - `value`: number | boolean | string | number[] | boolean[] | string[]
+- `type`: string, one of
+  - `"serverInitiated"` - The message was sent by the server without being previously requested
+  - `"getParametersResponse"` - The message was sent as a response to the client's [Get Parameters request](#get-parameters)
+  - `"valueUpdate"` - The message was sent because one or more [subscribed](#subscribe-parameter-update) parameters have changed their value
+- `id`: string | undefined. Only set when `type` is `"getParametersResponse"` and the [request's](#get-parameters) `id` field was set
 
 #### Example
 
@@ -166,7 +165,9 @@ The server may send this message
     { "name": "/float_param", "value": 1.2 },
     { "name": "/string_param", "value": "foo" },
     { "name": "/node/nested_ints_param", "value": [1, 2, 3] }
-  ]
+  ],
+  "type": "getParametersResponse",
+  "id": "request-123"
 }
 ```
 
@@ -281,6 +282,7 @@ Request one or more parameters. Only supported if the server previously declared
 
 - `op`: string `"getParameters"`
 - `parameterNames`: string[], leave empty to retrieve all currently set parameters
+- `id`: string | undefined, arbitrary string used for identifying the corresponding server [response](#parameter-values)
 
 #### Example
 
@@ -292,7 +294,8 @@ Request one or more parameters. Only supported if the server previously declared
     "/float_param",
     "/string_param",
     "/node/nested_ints_param"
-  ]
+  ],
+  "id": "request-123"
 }
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -29,7 +29,6 @@
 - [Unadvertise](#unadvertise) (json)
 - [Message Data](#message-data) (binary)
 - [Parameter Values](#parameter-values) (json)
-- [Parameter Updates](#parameter-updates) (json)
 
 ### Sent by client
 
@@ -58,7 +57,7 @@ Each JSON message must be an object containing a field called `op` which identif
 - `capabilities`: array of strings, informing the client about which optional features are supported
   - `clientPublish`: Allow clients to advertise channels to send data messages to the server
   - `parameters`: Allow clients to get & set parameters
-  - `parameterSubscribe`: Allow clients to subscribe to parameter changes
+  - `parametersSubscribe`: Allow clients to subscribe to parameter changes
 
 #### Example
 
@@ -161,29 +160,6 @@ Informs the client about parameters. The server may send this message arbitraril
     { "name": "/float_param", "value": 1.2 },
     { "name": "/string_param", "value": "foo" },
     { "name": "/node/nested_ints_param", "value": [1, 2, 3] }
-  ]
-}
-```
-
-### Parameter Updates
-
-Informs the client about updates of parameters that the client previously [subscribed](#subscribe-parameter-update) to. Only supported if the server declares the `parameterSubscribe` [capability](#server-info).
-
-#### Fields
-
-- `op`: string `"parameterUpdates"`
-- `parameters`: array of:
-  - `name`: string
-  - `value`: number | boolean | string | number[] | boolean[] | string[]
-
-#### Example
-
-```json
-{
-  "op": "parameterUpdates",
-  "parameters": [
-    { "name": "/int_param", "value": 3 },
-    { "name": "/float_param", "value": 3.1 }
   ]
 }
 ```
@@ -339,7 +315,7 @@ Set one or more parameters. Only supported if the server previously declared tha
 
 ### Subscribe Parameter Update
 
-Subscribe to parameter updates. Only supported if the server previously declared that it has the `parameterSubscribe` [capability](#server-info).
+Subscribe to parameter updates. Only supported if the server previously declared that it has the `parametersSubscribe` [capability](#server-info).
 
 Sending `subscribeParameterUpdates` multiple times will append the list of parameter subscriptions, not replace them. Note that parameters can be subscribed at most once. Hence, this operation will ignore parameters that are already subscribed. Use [unsubscribeParameterUdpates](#unsubscribe-parameter-update) to unsubscribe from existing parameter subscriptions.
 
@@ -364,7 +340,7 @@ Sending `subscribeParameterUpdates` multiple times will append the list of param
 
 ### Unsubscribe Parameter Update
 
-Unsubscribe from parameter updates. Only supported if the server previously declared that it has the `parameterSubscribe` [capability](#server-info).
+Unsubscribe from parameter updates. Only supported if the server previously declared that it has the `parametersSubscribe` [capability](#server-info).
 
 #### Fields
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -149,11 +149,7 @@ Informs the client about parameters. Only supported if the server declares the `
 - `parameters`: array of:
   - `name`: string, name of the parameter
   - `value`: number | boolean | string | number[] | boolean[] | string[]
-- `type`: string, one of
-  - `"serverInitiated"` - The message was sent by the server without being previously requested
-  - `"getParametersResponse"` - The message was sent as a response to the client's [Get Parameters request](#get-parameters)
-  - `"valueUpdate"` - The message was sent because one or more [subscribed](#subscribe-parameter-update) parameters have changed their value
-- `id`: string | undefined. Only set when `type` is `"getParametersResponse"` and the [request's](#get-parameters) `id` field was set
+- `id`: string | undefined. Only set when the [request's](#get-parameters) `id` field was set
 
 #### Example
 
@@ -166,7 +162,6 @@ Informs the client about parameters. Only supported if the server declares the `
     { "name": "/string_param", "value": "foo" },
     { "name": "/node/nested_ints_param", "value": [1, 2, 3] }
   ],
-  "type": "getParametersResponse",
   "id": "request-123"
 }
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,7 +141,13 @@ Informs the client that channels are no longer available.
 
 ### Parameter Values
 
-Informs the client about parameters. The server may send this message arbitrarily or as a response to the client's [Get Parameters request](#get-parameters). Only supported if the server declares the `parameters` [capability](#server-info).
+Informs the client about parameters. Only supported if the server declares the `parameters` [capability](#server-info).
+
+The server may send this message
+
+- at arbitrary points in time
+- as a response to the client's [Get Parameters request](#get-parameters)
+- when parameters have changed which were [subscribed](#subscribe-parameter-update) by the client
 
 #### Fields
 


### PR DESCRIPTION
**Public-Facing Changes**
Extend spec with parameter support


**Description**
Adds the following new capabilities to the spec

  - `parameters`: Allow clients to get & set parameters
  - `parameterSubscribe`: Allow clients to subscribe to parameter changes
