### PR TITLE
Spec: Add `clockTopic` field to `serverInfo` message

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -51,6 +51,7 @@ Each JSON message must be an object containing a field called `op` which identif
 - `name`: free-form information about the server which the client may optionally display or use for debugging purposes
 - `capabilities`: array of strings, informing the client about which optional features are supported
   - `clientPublish`: Allow clients to advertise channels to send data messages to the server
+- `clockTopic`: string | undefined, the topic name of the channel on which clock messages are published. If present, clients may subscribe to this channel to receive updates of the server's current time.
 
 #### Example
 


### PR DESCRIPTION
**Public-Facing Changes**
- Update spec by adding `clockTopic` field to `serverInfo` message

**Description**
In ROS systems, the `/clock` topic tells subscribers about the current time of the system. Clients, like Foxglove Studio, may want to subscribe to this topic. In order to stay ROS agnostic, a `clockTopic` field was added which is used to inform clients about the clock topic name
