### PR TITLE
Extend spec with publishing time data

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -59,6 +59,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `clientPublish`: Allow clients to advertise channels to send data messages to the server
   - `parameters`: Allow clients to get & set parameters
   - `parametersSubscribe`: Allow clients to subscribe to parameter changes
+  - `time`: The server may publish binary [time](#time) messages
 
 #### Example
 
@@ -66,7 +67,7 @@ Each JSON message must be an object containing a field called `op` which identif
 {
   "op": "serverInfo",
   "name": "example server",
-  "capabilities": ["clientPublish"]
+  "capabilities": ["clientPublish", "time"]
 }
 ```
 
@@ -388,6 +389,7 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 
 - Inform clients about the latest server time. This allows accelerated, slowed, or stepped control over the progress of time.
 - If the server publishes time data, then timestamps of [published messages](#message-data) must originate from the same time source
+- The server may only publish time data if it previously declared support for it via the `time` [capability](#server-info)
 
 | Bytes | Type   | Description             |
 | ----- | ------ | ----------------------- |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -28,6 +28,7 @@
 - [Advertise](#advertise) (json)
 - [Unadvertise](#unadvertise) (json)
 - [Message Data](#message-data) (binary)
+- [Time](#time) (binary)
 - [Parameter Values](#parameter-values) (json)
 
 ### Sent by client
@@ -382,3 +383,13 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 | 4               | uint32  | subscription id                 |
 | 8               | uint64  | receive timestamp (nanoseconds) |
 | remaining bytes | uint8[] | message payload                 |
+
+### Time
+
+- Inform clients about the latest server time. This allows accelerated, slowed, or stepped control over the progress of time.
+- If the server publishes time data, then timestamps of [published messages](#message-data) must originate from the same time source
+
+| Bytes | Type   | Description             |
+| ----- | ------ | ----------------------- |
+| 1     | opcode | 0x02                    |
+| 8     | uint64 | timestamp (nanoseconds) |

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -11,6 +11,7 @@ import {
   IWebSocket,
   ServerMessage,
   SubscriptionId,
+  TimeData,
 } from "./types";
 
 type EventTypes = {
@@ -21,6 +22,7 @@ type EventTypes = {
   serverInfo: (event: ServerInfo) => void;
   status: (event: StatusMessage) => void;
   message: (event: MessageData) => void;
+  time: (event: TimeData) => void;
   advertise: (newChannels: Channel[]) => void;
   unadvertise: (removedChannels: ChannelId[]) => void;
 };
@@ -90,6 +92,10 @@ export default class FoxgloveClient {
 
         case BinaryOpcode.MESSAGE_DATA:
           this.emitter.emit("message", message);
+          return;
+
+        case BinaryOpcode.TIME:
+          this.emitter.emit("time", message);
           return;
       }
       this.emitter.emit(

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -11,7 +11,7 @@ import {
   IWebSocket,
   ServerMessage,
   SubscriptionId,
-  TimeData,
+  Time,
 } from "./types";
 
 type EventTypes = {
@@ -22,7 +22,7 @@ type EventTypes = {
   serverInfo: (event: ServerInfo) => void;
   status: (event: StatusMessage) => void;
   message: (event: MessageData) => void;
-  time: (event: TimeData) => void;
+  time: (event: Time) => void;
   advertise: (newChannels: Channel[]) => void;
   unadvertise: (removedChannels: ChannelId[]) => void;
 };

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -79,7 +79,7 @@ describe("FoxgloveServer", () => {
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "serverInfo",
         name: "foo",
-        capabilities: ["clientPublish"],
+        capabilities: ["clientPublish", "time"],
       });
     } finally {
       close();
@@ -100,7 +100,7 @@ describe("FoxgloveServer", () => {
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "serverInfo",
         name: "foo",
-        capabilities: ["clientPublish"],
+        capabilities: ["clientPublish", "time"],
       });
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "advertise",
@@ -118,7 +118,7 @@ describe("FoxgloveServer", () => {
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "serverInfo",
         name: "foo",
-        capabilities: ["clientPublish"],
+        capabilities: ["clientPublish", "time"],
       });
 
       const chan = {
@@ -154,7 +154,7 @@ describe("FoxgloveServer", () => {
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "serverInfo",
         name: "foo",
-        capabilities: ["clientPublish"],
+        capabilities: ["clientPublish", "time"],
       });
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "advertise",
@@ -193,7 +193,7 @@ describe("FoxgloveServer", () => {
       await expect(nextJsonMessage()).resolves.toEqual({
         op: "serverInfo",
         name: "foo",
-        capabilities: ["clientPublish"],
+        capabilities: ["clientPublish", "time"],
       });
 
       // client message, this will be ignored since it is not preceded by an "advertise"
@@ -246,5 +246,25 @@ describe("FoxgloveServer", () => {
       throw ex;
     }
     close();
+  });
+
+  it("sends time messages to clients", async () => {
+    const server = new FoxgloveServer({ name: "foo" });
+    const { nextJsonMessage, nextBinaryMessage, close } = await setupServerAndClient(server);
+    try {
+      await expect(nextJsonMessage()).resolves.toEqual({
+        op: "serverInfo",
+        name: "foo",
+        capabilities: ["clientPublish", "time"],
+      });
+
+      server.broadcastTime(42n);
+
+      await expect(nextBinaryMessage()).resolves.toEqual(
+        new Uint8Array([BinaryOpcode.TIME, ...uint64LE(42n)]),
+      );
+    } finally {
+      close();
+    }
   });
 });

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -125,7 +125,7 @@ export default class FoxgloveServer {
   }
 
   /**
-   * Emit a time udpate to clients.
+   * Emit a time update to clients.
    */
   broadcastTime(timestamp: bigint): void {
     for (const client of this.clients.values()) {
@@ -390,15 +390,6 @@ export default class FoxgloveServer {
     msg.setUint8(0, BinaryOpcode.TIME);
     msg.setBigUint64(1, timestamp, true);
 
-    // attempt to detect support for {fin: false}
-    if (connection.send.length > 1) {
-      connection.send(msg, { fin: true });
-    } else if (typeof Blob === "function") {
-      connection.send(new Blob([msg]));
-    } else {
-      const buffer = new Uint8Array(msg.byteLength);
-      buffer.set(new Uint8Array(msg.buffer), 0);
-      connection.send(buffer);
-    }
+    connection.send(msg);
   }
 }

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -16,6 +16,10 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
       const data = new DataView(buffer, offset);
       return { op, subscriptionId, timestamp, data };
     }
+    case BinaryOpcode.TIME: {
+      const timestamp = view.getBigUint64(offset, true);
+      return { op, timestamp };
+    }
   }
   throw new Error(`Unrecognized server opcode in binary message: ${op.toString(16)}`);
 }

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -80,7 +80,7 @@ export type MessageData = {
   timestamp: bigint;
   data: DataView;
 };
-export type TimeData = {
+export type Time = {
   op: BinaryOpcode.TIME;
   timestamp: bigint;
 };
@@ -95,7 +95,7 @@ export type ServerMessage =
   | Advertise
   | Unadvertise
   | MessageData
-  | TimeData;
+  | Time;
 
 /**
  * Abstraction that supports both browser and Node WebSocket clients.

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -1,5 +1,6 @@
 export enum BinaryOpcode {
   MESSAGE_DATA = 1,
+  TIME = 2,
 }
 export enum ClientBinaryOpcode {
   MESSAGE_DATA = 1,
@@ -11,6 +12,7 @@ export enum StatusLevel {
 }
 export enum ServerCapability {
   clientPublish = "clientPublish",
+  time = "time",
 }
 
 export type ChannelId = number;
@@ -78,12 +80,22 @@ export type MessageData = {
   timestamp: bigint;
   data: DataView;
 };
+export type TimeData = {
+  op: BinaryOpcode.TIME;
+  timestamp: bigint;
+};
 export type ClientPublish = {
   channel: ClientChannel;
   data: DataView;
 };
 
-export type ServerMessage = ServerInfo | StatusMessage | Advertise | Unadvertise | MessageData;
+export type ServerMessage =
+  | ServerInfo
+  | StatusMessage
+  | Advertise
+  | Unadvertise
+  | MessageData
+  | TimeData;
 
 /**
  * Abstraction that supports both browser and Node WebSocket clients.


### PR DESCRIPTION
**Public-Facing Changes**
- Allow server to publish time data (binary)
- Adapt typescript client/server accordingly


**Description**
- Extends the spec by adding publishing of time data under a new opcode (0x02). By publishing time data, clients can be informed about the progress of time even if no other message data is published.
- Updates `@foxglove/ws-protocol` accordingly



Supersedes #298 
