### PR TITLE
Disable action-docker-layer-caching in CI (2x CI speedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,5 @@ jobs:
         working-directory: cpp
     steps:
       - uses: actions/checkout@v3
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
       - run: make format-check
       - run: make build


### PR DESCRIPTION
**Public-Facing Changes**
- None

**Description**
This CI step takes more time than it saves. It appears to spend 6+ minutes saving ~2 minutes.
