### PR TITLE
Fix dependabot config for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     labels: [] # disable default labels
 
   - package-ecosystem: pip
-    directory: "/python"
+    directory: "/"
     schedule:
       interval: weekly
     labels: [] # disable default labels


### PR DESCRIPTION
Dependabot is complaining that it can't find Python dependency stuff in `/python`. We have Pipfile things in `/`, although there are still some dependencies in `/python` so I'm not sure if this is the ideal setup. But maybe it'll be a little less broken.