### PR TITLE
Allow to configure capabilities in typescript server implementation

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/param-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/param-server.ts
@@ -1,4 +1,4 @@
-import { FoxgloveServer, Parameter } from "@foxglove/ws-protocol";
+import { FoxgloveServer, Parameter, ServerCapability } from "@foxglove/ws-protocol";
 import { Command } from "commander";
 import Debug from "debug";
 import { WebSocketServer } from "ws";
@@ -9,7 +9,10 @@ const log = Debug("foxglove:param-server");
 Debug.enable("foxglove:*");
 
 async function main(): Promise<void> {
-  const server = new FoxgloveServer({ name: "param-server" });
+  const server = new FoxgloveServer({
+    name: "param-server",
+    capabilities: [ServerCapability.parameters, ServerCapability.parametersSubscribe],
+  });
   const port = 8765;
   const ws = new WebSocketServer({
     port,

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -56,17 +56,33 @@ type EventTypes = {
 
 const log = createDebug("foxglove:server");
 
+const REQUIRED_CAPABILITY_BY_OPERATION: Record<
+  ClientMessage["op"],
+  keyof typeof ServerCapability | undefined
+> = {
+  subscribe: undefined,
+  unsubscribe: undefined,
+  advertise: ServerCapability.clientPublish,
+  unadvertise: ServerCapability.clientPublish,
+  getParameters: ServerCapability.parameters,
+  setParameters: ServerCapability.parameters,
+  subscribeParameterUpdates: ServerCapability.parametersSubscribe,
+  unsubscribeParameterUpdates: ServerCapability.parametersSubscribe,
+};
+
 export default class FoxgloveServer {
   static SUPPORTED_SUBPROTOCOL = "foxglove.websocket.v1";
 
   readonly name: string;
+  readonly capabilities: string[];
   private emitter = new EventEmitter<EventTypes>();
   private clients = new Map<IWebSocket, ClientInfo>();
   private nextChannelId: ChannelId = 0;
   private channels = new Map<ChannelId, Channel>();
 
-  constructor({ name }: { name: string }) {
+  constructor({ name, capabilities }: { name: string; capabilities?: string[] }) {
     this.name = name;
+    this.capabilities = capabilities ?? [];
   }
 
   on<E extends EventEmitter.EventNames<EventTypes>>(
@@ -203,12 +219,7 @@ export default class FoxgloveServer {
     this.send(connection, {
       op: "serverInfo",
       name: this.name,
-      capabilities: [
-        ServerCapability.clientPublish,
-        ServerCapability.time,
-        ServerCapability.parameters,
-        ServerCapability.parametersSubscribe,
-      ],
+      capabilities: this.capabilities,
     });
     if (this.channels.size > 0) {
       this.send(connection, { op: "advertise", channels: Array.from(this.channels.values()) });
@@ -284,6 +295,16 @@ export default class FoxgloveServer {
   }
 
   private handleClientMessage(client: ClientInfo, message: ClientMessage): void {
+    const requiredCapability = REQUIRED_CAPABILITY_BY_OPERATION[message.op];
+    if (requiredCapability && !this.capabilities.includes(requiredCapability)) {
+      log(
+        "Operation '%s' is not supported, as the server has not declared the capability '%s'.",
+        message.op,
+        requiredCapability,
+      );
+      return;
+    }
+
     switch (message.op) {
       case "subscribe":
         for (const { channelId, id: subId } of message.subscriptions) {

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -163,6 +163,14 @@ export default class FoxgloveServer {
    * Emit a time update to clients.
    */
   broadcastTime(timestamp: bigint): void {
+    if (!this.capabilities.includes(ServerCapability.time)) {
+      log(
+        "Sending time data is only supported if the server has declared the '%s' capability before.",
+        ServerCapability.time,
+      );
+      return;
+    }
+
     for (const client of this.clients.values()) {
       this.sendTimeData(client.connection, timestamp);
     }
@@ -175,6 +183,14 @@ export default class FoxgloveServer {
    * @param connection Optional connection when parameter values are to be sent to a single client
    */
   publishParameterValues(parameters: Parameter[], id?: string, connection?: IWebSocket): void {
+    if (!this.capabilities.includes(ServerCapability.parameters)) {
+      log(
+        "Publishing parameter values is only supported if the server has declared the '%s' capability before.",
+        ServerCapability.parameters,
+      );
+      return;
+    }
+
     if (connection) {
       this.send(connection, { op: "parameterValues", parameters, id });
     } else {
@@ -189,6 +205,14 @@ export default class FoxgloveServer {
    * @param parameters Parameter values
    */
   updateParameterValues(parameters: Parameter[]): void {
+    if (!this.capabilities.includes(ServerCapability.parametersSubscribe)) {
+      log(
+        "Publishing parameter value updates is only supported if the server has declared the '%s' capability before.",
+        ServerCapability.parametersSubscribe,
+      );
+      return;
+    }
+
     for (const client of this.clients.values()) {
       const parametersOfInterest = parameters.filter((p) =>
         client.parameterSubscriptions.has(p.name),

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -165,7 +165,7 @@ export default class FoxgloveServer {
   broadcastTime(timestamp: bigint): void {
     if (!this.capabilities.includes(ServerCapability.time)) {
       log(
-        "Sending time data is only supported if the server has declared the '%s' capability before.",
+        "Sending time data is only supported if the server has declared the '%s' capability.",
         ServerCapability.time,
       );
       return;
@@ -185,7 +185,7 @@ export default class FoxgloveServer {
   publishParameterValues(parameters: Parameter[], id?: string, connection?: IWebSocket): void {
     if (!this.capabilities.includes(ServerCapability.parameters)) {
       log(
-        "Publishing parameter values is only supported if the server has declared the '%s' capability before.",
+        "Publishing parameter values is only supported if the server has declared the '%s' capability.",
         ServerCapability.parameters,
       );
       return;
@@ -207,7 +207,7 @@ export default class FoxgloveServer {
   updateParameterValues(parameters: Parameter[]): void {
     if (!this.capabilities.includes(ServerCapability.parametersSubscribe)) {
       log(
-        "Publishing parameter value updates is only supported if the server has declared the '%s' capability before.",
+        "Publishing parameter value updates is only supported if the server has declared the '%s' capability.",
         ServerCapability.parametersSubscribe,
       );
       return;


### PR DESCRIPTION
**Public-Facing Changes**
- Allow to configure capabilities in typescript server implementation


**Description**
So far, capabilities of the typescript server implementation were hardcoded. With this PR, capabilities can be configured via a constructor argument. See also https://github.com/foxglove/ws-protocol/pull/319#discussion_r1062854374

