### PR TITLE
 Allow server to communicate supported encodings

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -60,6 +60,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `parameters`: Allow clients to get & set parameters
   - `parametersSubscribe`: Allow clients to subscribe to parameter changes
   - `time`: The server may publish binary [time](#time) messages
+- `supportedEncodings`: array of strings | undefined, informing the client about which encodings may be used for client side publishing
 
 #### Example
 
@@ -67,7 +68,8 @@ Each JSON message must be an object containing a field called `op` which identif
 {
   "op": "serverInfo",
   "name": "example server",
-  "capabilities": ["clientPublish", "time"]
+  "capabilities": ["clientPublish", "time"],
+  "supportedEncodings": ["json"]
 }
 ```
 
@@ -220,7 +222,7 @@ Informs the client about parameters. Only supported if the server declares the `
 - `channels`: array of:
   - `id`: number chosen by the client. The client may reuse ids that have previously been unadvertised.
   - `topic`: string
-  - `encoding`: string
+  - `encoding`: string, one of the encodings [supported by the server](#server-info)
   - `schemaName`: string
 
 #### Example

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -60,7 +60,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `parameters`: Allow clients to get & set parameters
   - `parametersSubscribe`: Allow clients to subscribe to parameter changes
   - `time`: The server may publish binary [time](#time) messages
-- `supportedEncodings`: array of strings | undefined, informing the client about which encodings may be used for client side publishing
+- `supportedEncodings`: array of strings | informing the client about which encodings may be used for client-side publishing. Only set if client publishing is supported.
 
 #### Example
 

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -197,6 +197,7 @@ describe("FoxgloveServer", () => {
     const server = new FoxgloveServer({
       name: "foo",
       capabilities: [ServerCapability.clientPublish],
+      supportedEncodings: ["json"],
     });
     const { send, nextJsonMessage, nextEvent, close } = await setupServerAndClient(server);
 
@@ -205,6 +206,7 @@ describe("FoxgloveServer", () => {
         op: "serverInfo",
         name: "foo",
         capabilities: ["clientPublish"],
+        supportedEncodings: ["json"],
       });
 
       // client message, this will be ignored since it is not preceded by an "advertise"
@@ -215,7 +217,7 @@ describe("FoxgloveServer", () => {
       send(
         JSON.stringify({
           op: "advertise",
-          channels: [{ id: 42, topic: "foo", encoding: "bar", schemaName: "baz" }],
+          channels: [{ id: 42, topic: "foo", encoding: "json", schemaName: "baz" }],
         }),
       );
 
@@ -233,7 +235,7 @@ describe("FoxgloveServer", () => {
 
       await expect(nextEvent()).resolves.toMatchObject([
         "advertise",
-        { id: 42, topic: "foo", encoding: "bar", schemaName: "baz" },
+        { id: 42, topic: "foo", encoding: "json", schemaName: "baz" },
       ]);
 
       const expectedPayload = new Uint8Array([2, 3, 4]);
@@ -241,7 +243,7 @@ describe("FoxgloveServer", () => {
       expect(msgEvent).toMatchObject([
         "message",
         {
-          channel: { id: 42, topic: "foo", encoding: "bar", schemaName: "baz" },
+          channel: { id: 42, topic: "foo", encoding: "json", schemaName: "baz" },
           data: new DataView(expectedPayload.buffer),
         },
       ]);

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -75,14 +75,24 @@ export default class FoxgloveServer {
 
   readonly name: string;
   readonly capabilities: string[];
+  readonly supportedEncodings?: string[];
   private emitter = new EventEmitter<EventTypes>();
   private clients = new Map<IWebSocket, ClientInfo>();
   private nextChannelId: ChannelId = 0;
   private channels = new Map<ChannelId, Channel>();
 
-  constructor({ name, capabilities }: { name: string; capabilities?: string[] }) {
+  constructor({
+    name,
+    capabilities,
+    supportedEncodings,
+  }: {
+    name: string;
+    capabilities?: string[];
+    supportedEncodings?: string[];
+  }) {
     this.name = name;
     this.capabilities = capabilities ?? [];
+    this.supportedEncodings = supportedEncodings;
   }
 
   on<E extends EventEmitter.EventNames<EventTypes>>(
@@ -244,6 +254,7 @@ export default class FoxgloveServer {
       op: "serverInfo",
       name: this.name,
       capabilities: this.capabilities,
+      supportedEncodings: this.supportedEncodings,
     });
     if (this.channels.size > 0) {
       this.send(connection, { op: "advertise", channels: Array.from(this.channels.values()) });

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -70,6 +70,7 @@ export type ServerInfo = {
   op: "serverInfo";
   name: string;
   capabilities: string[];
+  supportedEncodings?: string[];
 };
 export type StatusMessage = {
   op: "status";


### PR DESCRIPTION
**Public-Facing Changes**
-  Allow server to communicate supported encodings

**Description**
A client currently has no way in determining which message encodings the server supports for client publishing. This PR adds a field to the `serverInfo` message which informs clients about supported encodings.