### PR TITLE
Allow specifying a request id when setting parameters

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -151,7 +151,7 @@ Informs the client about parameters. Only supported if the server declares the `
 - `parameters`: array of:
   - `name`: string, name of the parameter
   - `value`: number | boolean | string | number[] | boolean[] | string[]
-- `id`: string | undefined. Only set when the [request's](#get-parameters) `id` field was set
+- `id`: string | undefined. Only set when the [getParameters](#get-parameters) or [setParameters](#set-parameters) request's `id` field was set
 
 #### Example
 
@@ -306,6 +306,7 @@ Set one or more parameters. Only supported if the server previously declared tha
 - `parameters`: array of:
   - `name`: string
   - `value`: number | boolean | string | number[] | boolean[] | string[]
+- `id`: string | undefined, arbitrary string used for identifying the corresponding server [response](#parameter-values). If this field is not set, the server may not send a response to the client.
 
 #### Example
 
@@ -315,7 +316,8 @@ Set one or more parameters. Only supported if the server previously declared tha
   "parameters": [
     { "name": "/int_param", "value": 3 },
     { "name": "/float_param", "value": 4.1 }
-  ]
+  ],
+  "id": "request-456"
 }
 ```
 

--- a/typescript/ws-protocol-examples/src/examples/param-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/param-server.ts
@@ -52,10 +52,18 @@ async function main(): Promise<void> {
       server.publishParameterValues(allParams, id, clientConnection);
     }
   });
-  server.on("setParameters", (parameters) => {
+  server.on("setParameters", ({ parameters, id }, clientConnection) => {
     log("Received a request to set %d parameters.", parameters.length);
     parameters.forEach((p) => paramStore.set(p.name, p.value));
     server.updateParameterValues(parameters);
+
+    if (id) {
+      // Send updated parameters to client
+      const params = Array.from(paramStore.entries())
+        .filter(([name]) => parameters.find((p) => p.name === name))
+        .map(([name, value]) => ({ name, value }));
+      server.publishParameterValues(params, id, clientConnection);
+    }
   });
   server.on("error", (err) => {
     log("server error: %o", err);

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -152,8 +152,8 @@ export default class FoxgloveClient {
     this.send({ op: "getParameters", parameterNames, id });
   }
 
-  setParameters(parameters: Parameter[]): void {
-    this.send({ op: "setParameters", parameters });
+  setParameters(parameters: Parameter[], id?: string): void {
+    this.send({ op: "setParameters", parameters, id });
   }
 
   subscribeParameterUpdates(parameterNames: string[]): void {

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -309,10 +309,10 @@ describe("FoxgloveServer", () => {
       const setParameters = await nextEvent();
       expect(setParameters).toMatchObject([
         "setParameters",
-        [{ name: "/foo/bool_param", value: false }],
+        { parameters: [{ name: "/foo/bool_param", value: false }] },
       ]);
-      const parameters = setParameters[1] as Parameter[];
-      paramStore = paramStore.map((p) => parameters.find((p2) => p2.name === p.name) ?? p);
+      const request = setParameters[1] as { parameters: Parameter[] };
+      paramStore = paramStore.map((p) => request.parameters.find((p2) => p2.name === p.name) ?? p);
 
       // client get parameter request
       const paramNames = paramStore.map((p) => p.name);

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -47,7 +47,10 @@ type EventTypes = {
     clientConnection: IWebSocket | undefined,
   ) => void;
   /** Request to set parameter values has been received. */
-  setParameters: (parameters: Parameter[]) => void;
+  setParameters: (
+    request: { parameters: Parameter[]; id?: string },
+    clientConnection: IWebSocket | undefined,
+  ) => void;
   /** Request to subscribe to parameter value updates has been received. */
   subscribeParameterUpdates: (parameterNames: string[]) => void;
   /** Request to unsubscribe from parameter value updates has been received. */
@@ -430,7 +433,7 @@ export default class FoxgloveServer {
         break;
 
       case "setParameters":
-        this.emitter.emit("setParameters", message.parameters);
+        this.emitter.emit("setParameters", { ...message }, client.connection);
         break;
 
       case "subscribeParameterUpdates":

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -97,6 +97,7 @@ export type GetParameters = {
 export type SetParameters = {
   op: "setParameters";
   parameters: Parameter[];
+  id?: string;
 };
 export type SubscribeParameterUpdates = {
   op: "subscribeParameterUpdates";


### PR DESCRIPTION
**Public-Facing Changes**
- Allow specifying a request id in the `setParameters` operation


**Description**
The server may reject requests to update parameters for various reasons such as e.g. parameters being readonly. To allow a client to verify if parameter updates were successful, this PR adds an optional request ID field to the `setParameters` operation. 

