### PR TITLE
Spec: Allow to send additional metadata to clients

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -61,6 +61,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `parametersSubscribe`: Allow clients to subscribe to parameter changes
   - `time`: The server may publish binary [time](#time) messages
 - `supportedEncodings`: array of strings | informing the client about which encodings may be used for client-side publishing. Only set if client publishing is supported.
+- `options`: optional map of key-value pairs
 
 #### Example
 
@@ -69,7 +70,10 @@ Each JSON message must be an object containing a field called `op` which identif
   "op": "serverInfo",
   "name": "example server",
   "capabilities": ["clientPublish", "time"],
-  "supportedEncodings": ["json"]
+  "supportedEncodings": ["json"],
+  "options": {
+    "key": "value"
+  }
 }
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -61,7 +61,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `parametersSubscribe`: Allow clients to subscribe to parameter changes
   - `time`: The server may publish binary [time](#time) messages
 - `supportedEncodings`: array of strings | informing the client about which encodings may be used for client-side publishing. Only set if client publishing is supported.
-- `options`: optional map of key-value pairs
+- `metadata`: optional map of key-value pairs
 
 #### Example
 
@@ -71,7 +71,7 @@ Each JSON message must be an object containing a field called `op` which identif
   "name": "example server",
   "capabilities": ["clientPublish", "time"],
   "supportedEncodings": ["json"],
-  "options": {
+  "metadata": {
     "key": "value"
   }
 }

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -65,7 +65,7 @@
     "@foxglove/rosmsg2-serialization": "^1.1.1",
     "@foxglove/rostime": "^1.1.2",
     "@foxglove/schemas": "^0.7.3",
-    "@foxglove/ws-protocol": "^0.3.2",
+    "@foxglove/ws-protocol": "^0.3.3",
     "@mcap/core": "^0.3.0",
     "boxen": "^7.0.1",
     "commander": "^9.5.0",

--- a/typescript/ws-protocol/package.json
+++ b/typescript/ws-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Foxglove Studio WebSocket protocol",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -71,6 +71,7 @@ export type ServerInfo = {
   name: string;
   capabilities: string[];
   supportedEncodings?: string[];
+  options?: Record<string, unknown>;
 };
 export type StatusMessage = {
   op: "status";

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -71,7 +71,7 @@ export type ServerInfo = {
   name: string;
   capabilities: string[];
   supportedEncodings?: string[];
-  options?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
 };
 export type StatusMessage = {
   op: "status";

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -71,7 +71,7 @@ export type ServerInfo = {
   name: string;
   capabilities: string[];
   supportedEncodings?: string[];
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, string>;
 };
 export type StatusMessage = {
   op: "status";


### PR DESCRIPTION
**Public-Facing Changes**
- Allow to send additional server options to clients


**Description**
Allows to inform clients about additional server options. E.g. for [foxglove-bridge  ](https://github.com/foxglove/ros-foxglove-bridge) we would like to communicate the ROS_DISTRO to the client
