### PR TITLE
TS examples: use @foxglove/schemas; better sigint behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,7 @@
   "python.testing.pytestEnabled": true,
   "python.formatting.provider": "black",
   "python.analysis.typeCheckingMode": "strict",
-  "jest.rootPath": "typescript",
+  "jest.rootPath": "typescript/ws-protocol",
 
   "search.exclude": {
     "**/*_pb2.py*": true,

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol-examples",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Foxglove WebSocket protocol examples",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -64,6 +64,7 @@
     "@foxglove/rosmsg-serialization": "^1.5.3",
     "@foxglove/rosmsg2-serialization": "^1.1.1",
     "@foxglove/rostime": "^1.1.2",
+    "@foxglove/schemas": "^0.7.3",
     "@foxglove/ws-protocol": "^0.3.2",
     "@mcap/core": "^0.3.0",
     "boxen": "^7.0.1",

--- a/typescript/ws-protocol-examples/src/examples/param-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/param-server.ts
@@ -4,6 +4,7 @@ import Debug from "debug";
 import { WebSocketServer } from "ws";
 
 import boxen from "../boxen";
+import { setupSigintHandler } from "./util/setupSigintHandler";
 
 const log = Debug("foxglove:param-server");
 Debug.enable("foxglove:*");
@@ -18,6 +19,7 @@ async function main(): Promise<void> {
     port,
     handleProtocols: (protocols) => server.handleProtocols(protocols),
   });
+  setupSigintHandler(log, ws);
 
   const paramStore = new Map<Parameter["name"], Parameter["value"]>([
     ["/foo/bool_param", true],

--- a/typescript/ws-protocol-examples/src/examples/sysmon.ts
+++ b/typescript/ws-protocol-examples/src/examples/sysmon.ts
@@ -5,6 +5,7 @@ import os from "os";
 import { WebSocketServer } from "ws";
 
 import boxen from "../boxen";
+import { setupSigintHandler } from "./util/setupSigintHandler";
 
 const log = Debug("foxglove:sysmon");
 Debug.enable("foxglove:*");
@@ -78,6 +79,7 @@ async function main() {
     port,
     handleProtocols: (protocols) => server.handleProtocols(protocols),
   });
+  setupSigintHandler(log, ws);
   ws.on("listening", () => {
     void boxen(
       `📡 Server listening on localhost:${port}. To see data, visit:\n` +

--- a/typescript/ws-protocol-examples/src/examples/util/setupSigintHandler.ts
+++ b/typescript/ws-protocol-examples/src/examples/util/setupSigintHandler.ts
@@ -1,0 +1,33 @@
+import { Debugger } from "debug";
+import { WebSocketServer, WebSocket } from "ws";
+
+/**
+ * Helper to set up a SIGINT handler that shuts down the server. It also closes each of the server's
+ * open clients, because if we don't, the server keeps running until active clients disconnect.
+ */
+export function setupSigintHandler(log: Debugger, ws: WebSocketServer): AbortSignal {
+  const controller = new AbortController();
+  const clientNames = new WeakMap<WebSocket, string>();
+  ws.on("connection", (conn, req) => {
+    const name = `${req.socket.remoteAddress!}:${req.socket.remotePort!}`;
+    clientNames.set(conn, name);
+  });
+  process.on("SIGINT", () => {
+    log("shutting down...");
+    controller.abort();
+
+    ws.close((err) => {
+      if (err) {
+        log("error shutting down", err);
+      } else {
+        log("server stopped");
+      }
+    });
+
+    for (const client of ws.clients) {
+      log("closing", clientNames.get(client) ?? "unknown");
+      client.close();
+    }
+  });
+  return controller.signal;
+}

--- a/typescript/ws-protocol/package.json
+++ b/typescript/ws-protocol/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "jest": "29.3.1",
     "prettier": "2.8.2",
-    "ts-jest": "29.0.3",
+    "ts-jest": "29.0.4",
     "ts-node": "10.9.1",
     "typescript": "4.9.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,6 +525,13 @@
     tsutils "^3"
     typescript "^4"
 
+"@foxglove/rosmsg-msgs-common@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-msgs-common/-/rosmsg-msgs-common-2.1.0.tgz#8d348db60dc69670916ca9dc56999abb6de4134f"
+  integrity sha512-Lxu3CEb+Ko1hrLu1bIqvvoc8DvGW1FAA21sWW0MoTPTgoQ1Rnpke2Z4H6O78C8DwXPzXAqZIisgxfFM9NYiHPA==
+  dependencies:
+    "@foxglove/rosmsg" "^3.1.0"
+
 "@foxglove/rosmsg-serialization@^1.5.3":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-serialization/-/rosmsg-serialization-1.5.3.tgz#82c311d81c1aec4319880ecb37208a2a74b1164a"
@@ -552,6 +559,14 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@foxglove/rostime/-/rostime-1.1.2.tgz#f8e1f10bff115c22be8a3e06791c2ac800449ee8"
   integrity sha512-vWuTJCuGv0xvgwOlrZ1y2MevmNMVxWcUU/HwlmYXi/jUq/kRaACStU18uyuZ3LzdNKaffkti0rTcXWESaQjwQw==
+
+"@foxglove/schemas@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@foxglove/schemas/-/schemas-0.7.3.tgz#720b03d6af1d1c77354ca70e373e6e4b8a3115ba"
+  integrity sha512-386DwFdLML/BpalrgmD49k0E0rmpECPH6rfiERdIJu8R+mBCZw1YVoS2A+durjv83NZC945wK7t84Pvfb9NTyw==
+  dependencies:
+    "@foxglove/rosmsg-msgs-common" "^2.0.0"
+    tslib "^2"
 
 "@foxglove/tsconfig@1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,6 +2978,11 @@ json5@^2.1.2, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3714,15 +3719,15 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ts-jest@29.0.3:
-  version "29.0.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.3.tgz#63ea93c5401ab73595440733cefdba31fcf9cb77"
-  integrity sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==
+ts-jest@29.0.4:
+  version "29.0.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.4.tgz#9bc1fd0ec4d863f001af6c5c630e3a807df90f6d"
+  integrity sha512-YdNofkoyzeinwjIqLSYQeAM+GTmFQ7xFNtWcR5OyitY5VLzzNINrNmfhP5H3daA/V+RGQR7O3g1K6ysRgu5xIQ==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
     jest-util "^29.0.0"
-    json5 "^2.2.1"
+    json5 "^2.2.3"
     lodash.memoize "4.x"
     make-error "1.x"
     semver "7.x"


### PR DESCRIPTION
**Public-Facing Changes**
Improved ^C exit behavior for `npx @foxglove/ws-protocol-examples`.
Updated TypeScript examples to use schemas from `@foxglove/schemas`.

**Description**
Our server scripts weren't shutting down cleanly on sigint. I thought `ws.close()` would work, but for some unknown reason I had to manually `close()` each of the currently open clients as well. Additionally, Yarn 1 doesn't wait for the child process before it exits (https://github.com/yarnpkg/yarn/issues/4667) which is probably why I didn't notice the issue when originally creating these scripts.

Fixes #162 