### PR TITLE
Add example for calling services

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/service-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-client.ts
@@ -1,0 +1,79 @@
+import { MessageWriter as Ros1MessageWriter } from "@foxglove/rosmsg-serialization";
+import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
+import { FoxgloveClient } from "@foxglove/ws-protocol";
+import { Command, Option } from "commander";
+import Debug from "debug";
+import WebSocket from "ws";
+
+const log = Debug("foxglove:service-client");
+Debug.enable("foxglove:*");
+
+async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
+  const address = url.startsWith("ws://") || url.startsWith("wss://") ? url : `ws://${url}`;
+  log(`Client connecting to ${address}`);
+  const client = new FoxgloveClient({
+    ws: new WebSocket(address, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
+  });
+  client.on("error", (error) => {
+    log("Error", error);
+    throw error;
+  });
+  client.on("serverInfo", (serverInfo) => {
+    const supportedEncodings = serverInfo.supportedEncodings ?? [];
+    if (!supportedEncodings.includes(args.encoding)) {
+      log(
+        "Error",
+        "Chosen encoding is not supported by the server. Server only supports the following encodings: ",
+        supportedEncodings,
+      );
+      client.close();
+    }
+  });
+  client.on("advertiseServices", (services) => {
+    const service = services.find((s) => /std_srvs(\/srv)?\/SetBool/.test(s.type));
+    if (!service) {
+      return;
+    }
+
+    let requestData: Uint8Array = new Uint8Array();
+    if (args.encoding === "json") {
+      requestData = new Uint8Array(Buffer.from(JSON.stringify({ data: true })));
+    } else if (args.encoding === "ros1") {
+      const writer = new Ros1MessageWriter([{ definitions: [{ name: "data", type: "bool" }] }]);
+      requestData = writer.writeMessage({ data: true });
+    } else if (args.encoding === "cdr") {
+      const writer = new Ros2MessageWriter([{ definitions: [{ name: "data", type: "bool" }] }]);
+      requestData = writer.writeMessage({ data: true });
+    }
+
+    client.sendServiceCallRequest({
+      serviceId: service.id,
+      callId: 123,
+      encoding: args.encoding,
+      data: new DataView(requestData.buffer),
+    });
+  });
+
+  client.on("serviceCallResponse", (response) => {
+    if (response.encoding === "json") {
+      const responseData = new TextDecoder().decode(response.data);
+      console.log(JSON.parse(responseData));
+    } else if (response.encoding === "ros1") {
+      console.log(response);
+    } else if (response.encoding === "cdr") {
+      console.log(response);
+    }
+
+    client.close();
+  });
+}
+
+export default new Command("service-client")
+  .description("connect to a server and call the first advertised SetBool service")
+  .addOption(
+    new Option("-e, --encoding <encoding>", "message encoding")
+      .choices(["json", "ros1", "cdr"])
+      .default("json"),
+  )
+  .argument("[url]", "ws(s)://host:port", "ws://localhost:8765")
+  .action(main);

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -1,0 +1,91 @@
+import { MessageWriter as Ros1MessageWriter } from "@foxglove/rosmsg-serialization";
+import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
+import { FoxgloveServer, ServerCapability, ServiceCallPayload } from "@foxglove/ws-protocol";
+import { Command } from "commander";
+import Debug from "debug";
+import { WebSocketServer } from "ws";
+
+import boxen from "../boxen";
+import { setupSigintHandler } from "./util/setupSigintHandler";
+
+const log = Debug("foxglove:service-server");
+Debug.enable("foxglove:*");
+
+async function main(): Promise<void> {
+  const supportedEncodings = ["json", "ros1", "cdr"];
+  const server = new FoxgloveServer({
+    name: "service-server",
+    capabilities: [ServerCapability.services],
+    supportedEncodings,
+  });
+  const port = 8765;
+  const ws = new WebSocketServer({
+    port,
+    handleProtocols: (protocols) => server.handleProtocols(protocols),
+  });
+  setupSigintHandler(log, ws);
+
+  const service = {
+    name: "/set_bool",
+    requestSchema: "bool data",
+    responseSchema: "bool success\nstring message",
+    type: "std_srvs/SetBool",
+  };
+  const serviceId = server.addService(service);
+
+  ws.on("listening", () => {
+    void boxen(
+      `📡 Server listening on localhost:${port}. To see data, visit:\n` +
+        `https://studio.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
+      { borderStyle: "round", padding: 1 },
+    ).then(log);
+  });
+  ws.on("connection", (conn, req) => {
+    const name = `${req.socket.remoteAddress!}:${req.socket.remotePort!}`;
+    log("connection from %s via %s", name, req.url);
+    server.handleConnection(conn, name);
+  });
+  server.on("serviceCallRequest", (request, clientConnection) => {
+    if (request.serviceId !== serviceId) {
+      throw new Error(`Received invalid serviceId: "${request.serviceId}"`);
+    }
+    if (!supportedEncodings.includes(request.encoding)) {
+      throw new Error(`Received invalid encoding: "${request.encoding}"`);
+    }
+
+    log("Received service call request with %d bytes", request.data.byteLength);
+
+    const responseMsg = {
+      success: true,
+      message: `Hello back`,
+    };
+
+    let responseData = new Uint8Array();
+    if (request.encoding === "json") {
+      responseData = new Uint8Array(Buffer.from(JSON.stringify(responseMsg)));
+    } else if (request.encoding === "ros1" || request.encoding === "cdr") {
+      const definitions = [
+        { name: "success", type: "bool" },
+        { name: "message", type: "string" },
+      ];
+      const writer =
+        request.encoding === "ros1"
+          ? new Ros1MessageWriter([{ definitions }])
+          : new Ros2MessageWriter([{ definitions }]);
+      responseData = writer.writeMessage(responseMsg);
+    }
+
+    const response: ServiceCallPayload = {
+      ...request,
+      data: new DataView(responseData.buffer),
+    };
+    server.sendServiceCallResponse(response, clientConnection);
+  });
+  server.on("error", (err) => {
+    log("server error: %o", err);
+  });
+}
+
+export default new Command("service-server")
+  .description("advertises a SetBool service that can be called")
+  .action(main);

--- a/typescript/ws-protocol-examples/src/index.ts
+++ b/typescript/ws-protocol-examples/src/index.ts
@@ -6,6 +6,8 @@ import McapPlay from "./examples/mcap-play";
 import ParamClient from "./examples/param-client";
 import ParamServer from "./examples/param-server";
 import PublishClient from "./examples/publish-client";
+import ServiceClient from "./examples/service-client";
+import ServiceServer from "./examples/service-server";
 import SimpleClient from "./examples/simple-client";
 import Sysmon from "./examples/sysmon";
 
@@ -17,5 +19,7 @@ program.addCommand(SimpleClient);
 program.addCommand(Sysmon);
 program.addCommand(ParamClient);
 program.addCommand(ParamServer);
+program.addCommand(ServiceClient);
+program.addCommand(ServiceServer);
 
 program.parseAsync().catch(console.error);

--- a/typescript/ws-protocol/package.json
+++ b/typescript/ws-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Foxglove Studio WebSocket protocol",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -194,7 +194,7 @@ export default class FoxgloveClient {
     this.ws.send(payload);
   }
 
-  sendCallServiceRequest(request: ServiceCallPayload): void {
+  sendServiceCallRequest(request: ServiceCallPayload): void {
     const encoding = textEncoder.encode(request.encoding);
     const payload = new Uint8Array(1 + 4 + 4 + 4 + encoding.length + request.data.byteLength);
     const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
@@ -216,6 +216,13 @@ export default class FoxgloveClient {
     );
     payload.set(data, offset);
     this.ws.send(payload);
+  }
+
+  /**
+   * @deprecated Use `sendServiceCallRequest` instead
+   */
+  sendCallServiceRequest(request: ServiceCallPayload): void {
+    this.sendServiceCallRequest(request);
   }
 
   private send(message: ClientMessage) {


### PR DESCRIPTION
**Public-Facing Changes**
- `@foxglove/ws-protocol-examples`: Add example for calling services
- `@foxglove/ws-protocol`: Rename method `sendCallServiceRequest` -> `sendServiceCallRequest`

**Description**
The service client is currently hardcoded to call the first `std_srvs/SetBool` advertised by the server.
