### PR TITLE
Example server implementation: Disallow multiple client subscriptions per channel per client

### DIFF
--- a/python/src/foxglove_websocket/server/client_state.py
+++ b/python/src/foxglove_websocket/server/client_state.py
@@ -25,8 +25,8 @@ class ClientState:
     )
 
     def remove_channel(self, removed_chan_id: ChannelId):
-        subId = self.subscriptions_by_channel.get(removed_chan_id)
-        if subId is not None:
+        sub_id = self.subscriptions_by_channel.get(removed_chan_id)
+        if sub_id is not None:
             self.subscriptions = MappingProxyType(
                 {
                     sub: chan

--- a/python/tests/test_client_state.py
+++ b/python/tests/test_client_state.py
@@ -11,15 +11,15 @@ def test_add_subscription():
 
     state.add_subscription(SubscriptionId(0), ChannelId(100))
     assert state.subscriptions == {0: 100}
-    assert state.subscriptions_by_channel == {100: {0}}
+    assert state.subscriptions_by_channel == {100: 0}
 
     state.add_subscription(SubscriptionId(1), ChannelId(101))
     assert state.subscriptions == {0: 100, 1: 101}
-    assert state.subscriptions_by_channel == {100: {0}, 101: {1}}
+    assert state.subscriptions_by_channel == {100: 0, 101: 1}
 
     state.add_subscription(SubscriptionId(2), ChannelId(101))
-    assert state.subscriptions == {0: 100, 1: 101, 2: 101}
-    assert state.subscriptions_by_channel == {100: {0}, 101: {1, 2}}
+    assert state.subscriptions == {0: 100, 1: 101}
+    assert state.subscriptions_by_channel == {100: 0, 101: 1}
 
 
 def test_remove_subscription():
@@ -28,22 +28,22 @@ def test_remove_subscription():
     assert state.subscriptions_by_channel == {}
 
     state.add_subscription(SubscriptionId(0), ChannelId(100))
-    state.add_subscription(SubscriptionId(1), ChannelId(100))
-    state.add_subscription(SubscriptionId(2), ChannelId(100))
-    assert state.subscriptions == {0: 100, 1: 100, 2: 100}
-    assert state.subscriptions_by_channel == {100: {0, 1, 2}}
+    state.add_subscription(SubscriptionId(1), ChannelId(101))
+    state.add_subscription(SubscriptionId(2), ChannelId(102))
+    assert state.subscriptions == {0: 100, 1: 101, 2: 102}
+    assert state.subscriptions_by_channel == {100: 0, 101: 1, 102: 2}
 
     assert state.remove_subscription(SubscriptionId(99)) is None
 
-    assert state.remove_subscription(SubscriptionId(1)) == 100
-    assert state.subscriptions == {0: 100, 2: 100}
-    assert state.subscriptions_by_channel == {100: {0, 2}}
+    assert state.remove_subscription(SubscriptionId(1)) == 101
+    assert state.subscriptions == {0: 100, 2: 102}
+    assert state.subscriptions_by_channel == {100: 0, 102: 2}
 
     assert state.remove_subscription(SubscriptionId(0)) == 100
-    assert state.subscriptions == {2: 100}
-    assert state.subscriptions_by_channel == {100: {2}}
+    assert state.subscriptions == {2: 102}
+    assert state.subscriptions_by_channel == {102: 2}
 
-    assert state.remove_subscription(SubscriptionId(2)) == 100
+    assert state.remove_subscription(SubscriptionId(2)) == 102
     assert state.subscriptions == {}
     assert state.subscriptions_by_channel == {}
 
@@ -56,20 +56,18 @@ def test_remove_channel():
     assert state.subscriptions_by_channel == {}
 
     state.add_subscription(SubscriptionId(0), ChannelId(100))
-    state.add_subscription(SubscriptionId(1), ChannelId(100))
-    state.add_subscription(SubscriptionId(2), ChannelId(100))
-    state.add_subscription(SubscriptionId(3), ChannelId(101))
+    state.add_subscription(SubscriptionId(1), ChannelId(101))
 
-    assert state.subscriptions == {0: 100, 1: 100, 2: 100, 3: 101}
-    assert state.subscriptions_by_channel == {100: {0, 1, 2}, 101: {3}}
+    assert state.subscriptions == {0: 100, 1: 101}
+    assert state.subscriptions_by_channel == {100: 0, 101: 1}
 
     state.remove_channel(ChannelId(999))
-    assert state.subscriptions == {0: 100, 1: 100, 2: 100, 3: 101}
-    assert state.subscriptions_by_channel == {100: {0, 1, 2}, 101: {3}}
+    assert state.subscriptions == {0: 100, 1: 101}
+    assert state.subscriptions_by_channel == {100: 0, 101: 1}
 
     state.remove_channel(ChannelId(100))
-    assert state.subscriptions == {3: 101}
-    assert state.subscriptions_by_channel == {101: {3}}
+    assert state.subscriptions == {1: 101}
+    assert state.subscriptions_by_channel == {101: 1}
 
     state.remove_channel(ChannelId(101))
     assert state.subscriptions == {}

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -26,7 +26,7 @@ type ClientInfo = {
   name: string;
   connection: IWebSocket;
   subscriptions: Map<SubscriptionId, ChannelId>;
-  subscriptionsByChannel: Map<ChannelId, Set<SubscriptionId>>;
+  subscriptionsByChannel: Map<ChannelId, SubscriptionId>;
   advertisements: Map<ClientChannelId, ClientChannel>;
   parameterSubscriptions: Set<string>;
 };
@@ -157,11 +157,9 @@ export default class FoxgloveServer {
       throw new Error(`Channel ${channelId} does not exist`);
     }
     for (const client of this.clients.values()) {
-      const subs = client.subscriptionsByChannel.get(channelId);
-      if (subs) {
-        for (const subId of subs) {
-          client.subscriptions.delete(subId);
-        }
+      const subId = client.subscriptionsByChannel.get(channelId);
+      if (subId != undefined) {
+        client.subscriptions.delete(subId);
         client.subscriptionsByChannel.delete(channelId);
       }
       this.send(client.connection, { op: "unadvertise", channelIds: [channelId] });
@@ -199,13 +197,11 @@ export default class FoxgloveServer {
    */
   sendMessage(chanId: ChannelId, timestamp: bigint, payload: BufferSource): void {
     for (const client of this.clients.values()) {
-      const subs = client.subscriptionsByChannel.get(chanId);
-      if (!subs) {
+      const subId = client.subscriptionsByChannel.get(chanId);
+      if (subId == undefined) {
         continue;
       }
-      for (const subId of subs) {
-        this.sendMessageData(client.connection, subId, timestamp, payload);
-      }
+      this.sendMessageData(client.connection, subId, timestamp, payload);
     }
   }
 
@@ -415,12 +411,7 @@ export default class FoxgloveServer {
           log("client %s subscribed to channel %d", client.name, channelId);
           const firstSubscription = !this.anySubscribed(channelId);
           client.subscriptions.set(subId, channelId);
-          let subs = client.subscriptionsByChannel.get(channelId);
-          if (!subs) {
-            subs = new Set();
-            client.subscriptionsByChannel.set(channelId, subs);
-          }
-          subs.add(subId);
+          client.subscriptionsByChannel.set(channelId, subId);
           if (firstSubscription) {
             this.emitter.emit("subscribe", channelId);
           }
@@ -440,12 +431,8 @@ export default class FoxgloveServer {
           }
           log("client %s unsubscribed from channel %d", client.name, chanId);
           client.subscriptions.delete(subId);
-          const subs = client.subscriptionsByChannel.get(chanId);
-          if (subs) {
-            subs.delete(subId);
-            if (subs.size === 0) {
-              client.subscriptionsByChannel.delete(chanId);
-            }
+          if (client.subscriptionsByChannel.has(chanId)) {
+            client.subscriptionsByChannel.delete(chanId);
           }
           if (!this.anySubscribed(chanId)) {
             this.emitter.emit("unsubscribe", chanId);

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -399,6 +399,14 @@ export default class FoxgloveServer {
             });
             continue;
           }
+          if (client.subscriptionsByChannel.has(channelId)) {
+            this.send(client.connection, {
+              op: "status",
+              level: StatusLevel.WARNING,
+              message: `Client already subscribed to channel ${channelId}; ignoring subscription`,
+            });
+            continue;
+          }
           const channel = this.channels.get(channelId);
           if (!channel) {
             this.send(client.connection, {


### PR DESCRIPTION
**Public-Facing Changes**
- Python / Typescript example implementation: Disallow multiple subscriptions per channel per client

**Description**
The spec says that clients may only have one subscription for each channel at a time. However, our reference implementation allowed having more than one subscription. This PR fixes this for the following reference implementations:

- [x] Typescript
- [x] Python
- [x] C++  (Fixed in #375)

fixes #233
fixes FG-957