### PR TITLE
Switch lz4 dep to @foxglove/wasm-lz4, test on nodejs 16+18 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [ws-protocol, ws-protocol-examples]
-        node-version: [16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         package: [ws-protocol, ws-protocol-examples]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org
           cache: yarn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [ws-protocol, ws-protocol-examples]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -19,7 +19,7 @@
     "email": "support@foxglove.dev"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "homepage": "https://foxglove.dev/",
   "module": "dist/esm/ws-protocol-examples/src/index.js",

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -66,7 +66,7 @@
     "@foxglove/rostime": "^1.1.2",
     "@foxglove/schemas": "^0.7.3",
     "@foxglove/wasm-lz4": "^1.0.2",
-    "@foxglove/ws-protocol": "^0.3.3",
+    "@foxglove/ws-protocol": "^0.4.0",
     "@mcap/core": "^0.3.0",
     "boxen": "^7.0.1",
     "commander": "^9.5.0",

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -65,6 +65,7 @@
     "@foxglove/rosmsg2-serialization": "^1.1.1",
     "@foxglove/rostime": "^1.1.2",
     "@foxglove/schemas": "^0.7.3",
+    "@foxglove/wasm-lz4": "^1.0.2",
     "@foxglove/ws-protocol": "^0.3.3",
     "@mcap/core": "^0.3.0",
     "boxen": "^7.0.1",
@@ -74,7 +75,6 @@
     "protobufjs": "^7.1.2",
     "pureimage": "^0.3.15",
     "tslib": "^2",
-    "wasm-lz4": "^2.0.0",
     "ws": "^8.12.0",
     "zstd-codec": "^0.1.4"
   }

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -19,7 +19,7 @@
     "email": "support@foxglove.dev"
   },
   "engines": {
-    "node": ">= 14 <18"
+    "node": ">= 14"
   },
   "homepage": "https://foxglove.dev/",
   "module": "dist/esm/ws-protocol-examples/src/index.js",

--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -3,7 +3,7 @@ import { McapIndexedReader, McapTypes } from "@mcap/core";
 import { Command } from "commander";
 import Debug from "debug";
 import fs from "fs/promises";
-import decompressLZ4 from "wasm-lz4";
+import decompressLZ4 from "@foxglove/wasm-lz4";
 import { WebSocketServer } from "ws";
 import { ZstdCodec, ZstdModule, ZstdStreaming } from "zstd-codec";
 

--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -1,9 +1,9 @@
+import decompressLZ4 from "@foxglove/wasm-lz4";
 import { FoxgloveServer } from "@foxglove/ws-protocol";
 import { McapIndexedReader, McapTypes } from "@mcap/core";
 import { Command } from "commander";
 import Debug from "debug";
 import fs from "fs/promises";
-import decompressLZ4 from "@foxglove/wasm-lz4";
 import { WebSocketServer } from "ws";
 import { ZstdCodec, ZstdModule, ZstdStreaming } from "zstd-codec";
 

--- a/typescript/ws-protocol-examples/src/wasm-lz4.d.ts
+++ b/typescript/ws-protocol-examples/src/wasm-lz4.d.ts
@@ -1,8 +1,0 @@
-declare module "wasm-lz4" {
-  function decompress(buffer: Uint8Array, size: number): Buffer;
-  namespace decompress {
-    const isLoaded: Promise<boolean>;
-  }
-
-  export default decompress;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,15 +578,6 @@
   resolved "https://registry.yarnpkg.com/@foxglove/wasm-lz4/-/wasm-lz4-1.0.2.tgz#ce8e27ae9c039058a033e288043f38acee3d1e2b"
   integrity sha512-qwGOVLITlMBwuI+Vf09xWkTtbQldaCKchGEiFNZzsY0Q6ZXnHFhFgl4UAew7Xaq0wCv5YB7hqYsHmSrFIVSjCg==
 
-"@foxglove/ws-protocol@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@foxglove/ws-protocol/-/ws-protocol-0.3.3.tgz#cc17a859bf52f0f151c24704eb5be29b830817ed"
-  integrity sha512-mtZmWc2DNoWwf1KHjkChxempZfKGxI8wjD3yBK5I2/oXxoz5GbHerniDlxm7nfUJw+sIs2dI4DfWoLtCOo1zjQ==
-  dependencies:
-    debug "^4"
-    eventemitter3 "^5.0.0"
-    tslib "^2"
-
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,6 +573,20 @@
   resolved "https://registry.yarnpkg.com/@foxglove/tsconfig/-/tsconfig-1.1.0.tgz#48c37fffd6f349c3ee08a60fc62ccf636f3b59a6"
   integrity sha512-qZU4MtXVgPhDBFazSEx7yDEuEg8cPHXFQVhBaUABZkCBdcnEE9sxlgEt0gSikF4fRtY6COGIJPVRflnPJXjJKA==
 
+"@foxglove/wasm-lz4@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@foxglove/wasm-lz4/-/wasm-lz4-1.0.2.tgz#ce8e27ae9c039058a033e288043f38acee3d1e2b"
+  integrity sha512-qwGOVLITlMBwuI+Vf09xWkTtbQldaCKchGEiFNZzsY0Q6ZXnHFhFgl4UAew7Xaq0wCv5YB7hqYsHmSrFIVSjCg==
+
+"@foxglove/ws-protocol@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@foxglove/ws-protocol/-/ws-protocol-0.3.3.tgz#cc17a859bf52f0f151c24704eb5be29b830817ed"
+  integrity sha512-mtZmWc2DNoWwf1KHjkChxempZfKGxI8wjD3yBK5I2/oXxoz5GbHerniDlxm7nfUJw+sIs2dI4DfWoLtCOo1zjQ==
+  dependencies:
+    debug "^4"
+    eventemitter3 "^5.0.0"
+    tslib "^2"
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -3856,11 +3870,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-wasm-lz4@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/wasm-lz4/-/wasm-lz4-2.0.0.tgz#f0e8cab698c8037f7259a66c8fc698ad87e01933"
-  integrity sha512-eXm4WpHRuS2O1yOOLGTyDDit+gBJ5wV6/VhR4b0p289pQDABu03eBfGvzua5YJN6teiIskH3eE4SyQTG4/HV9w==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
**Public-Facing Changes**
- ws-protocol-examples now run on nodejs 18.x

**Description**
Switched from `wasm-lz4` to `@foxglove/wasm-lz4` to fix node 18.x compatibility
