### PR TITLE
Spec: Add optional `sessionId` field to `serverInfo` message

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -67,6 +67,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `services`: Allow clients to call services
 - `supportedEncodings`: array of strings | informing the client about which encodings may be used for client-side publishing or service call requests/responses. Only set if client publishing or services are supported.
 - `metadata`: optional map of key-value pairs
+- `sessionId`: optional string. Allows the client to understand if the connection is a re-connection or if it is connecting to a new server instance. This can for example be a timestamp or a UUID.
 
 #### Example
 
@@ -78,7 +79,8 @@ Each JSON message must be an object containing a field called `op` which identif
   "supportedEncodings": ["json"],
   "metadata": {
     "key": "value"
-  }
+  },
+  "sessionId": "1675789422160"
 }
 ```
 


### PR DESCRIPTION
**Public-Facing Changes**
- Adds optional `sessionId` field to `serverInfo` message

**Description**
From #256:

> Including sessionId sent by server on opening connection allows client to understand context and if the connection is a re-connection from a dropped context, or if it is a new session connecting. We will then be able to clear state in the client when connecting to a new context, but retain state when reconnecting a dropped connection.
>
> Context: Customer is currently reconnecting to a websocket in a different context and the state is being preserved leading to incorrect results. They would like the state to be cleared when reconnecting to the WS in a new context.


Fixes #256

Linear: [FG-1654](https://linear.app/foxglove/issue/FG-1654/include-session-id-in-websocket-connection-%5Bfoxglovews-protocol-256%5D)
