### PR TITLE
@foxglove/ws-protocol-examples: Add client to print channel statistics

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/perf-test-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/perf-test-client.ts
@@ -1,0 +1,92 @@
+import { Channel, FoxgloveClient } from "@foxglove/ws-protocol";
+import { Command } from "commander";
+import Debug from "debug";
+import WebSocket from "ws";
+
+const log = Debug("foxglove:perf-test-client");
+Debug.enable("foxglove:*");
+
+async function main(url: string, topics: string) {
+  const address = url.startsWith("ws://") || url.startsWith("wss://") ? url : `ws://${url}`;
+  const topicsRegex = new RegExp(topics);
+
+  const channelsBySubId: Map<number, Channel> = new Map();
+  const channelStatsBySubId: Map<number, { timestamp: number; bytesRcvd: number }[]> = new Map();
+
+  const printStats = () => {
+    let totalKiloBytesRcvd = 0;
+
+    const topicWidth = [...channelsBySubId.values()].reduce(
+      (acc, x) => (x.topic.length > acc ? x.topic.length : acc),
+      0,
+    );
+    const nMsgsWidth = 9;
+    const nKbRcvdWidth = 14;
+
+    console.log(
+      `| ${"topic".padEnd(topicWidth)} | ${"Msgs rcvd".padEnd(nMsgsWidth)} | ${"kB rcvd".padEnd(
+        nKbRcvdWidth,
+      )} |`,
+    );
+    console.log(
+      `|-${"".padEnd(topicWidth, "-")}-|-${"".padEnd(nMsgsWidth, "-")}-|-${"".padEnd(
+        nKbRcvdWidth,
+        "-",
+      )}-|`,
+    );
+
+    channelsBySubId.forEach((channel, subId) => {
+      const stats = channelStatsBySubId.get(subId);
+      const sumBytesReceived = (stats?.reduce((acc, x) => acc + x.bytesRcvd, 0) ?? 0) / 1e3;
+      totalKiloBytesRcvd += sumBytesReceived;
+      const topicStr = channel.topic.padEnd(topicWidth);
+      const nMsgsStr = `${stats?.length ?? 0}`.padEnd(nMsgsWidth);
+      const sumBytesReceivedStr = `${sumBytesReceived.toFixed(2)}`.padEnd(nKbRcvdWidth);
+
+      console.log(`| ${topicStr} | ${nMsgsStr} | ${sumBytesReceivedStr} |`);
+    });
+
+    console.log(`\nTotal kB received: ${totalKiloBytesRcvd}`);
+  };
+
+  log(`Client connecting to ${address}`);
+  const client = new FoxgloveClient({
+    ws: new WebSocket(address, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
+  });
+  client.on("error", (error) => {
+    log("Error", error);
+    throw error;
+  });
+  client.on("advertise", (channels) => {
+    const subscribedChannelIds = [...channelsBySubId.values()].map((channel) => channel.id);
+    const newChannels = channels
+      .filter((c) => !subscribedChannelIds.includes(c.id))
+      .filter((c) => topicsRegex.test(c.topic));
+
+    for (const channel of newChannels) {
+      const subId = client.subscribe(channel.id);
+      channelsBySubId.set(subId, channel);
+      channelStatsBySubId.set(subId, []);
+    }
+  });
+  client.on("message", (event) => {
+    const rcvMsgs = channelStatsBySubId.get(event.subscriptionId);
+    rcvMsgs?.push({ timestamp: new Date().getTime(), bytesRcvd: event.data.byteLength });
+  });
+  client.on("close", printStats);
+
+  process.on("SIGINT", () => {
+    console.log("Caught interrupt signal");
+    client.close();
+    printStats();
+    process.exit();
+  });
+}
+
+export default new Command("perf-test-client")
+  .description(
+    "connect to a server and subscribe to all available channels. Print channel statistics on disconnect / exit",
+  )
+  .argument("[url]", "ws(s)://host:port", "ws://localhost:8765")
+  .argument("[topics]", "regex for topics to subscribe", ".*")
+  .action(main);

--- a/typescript/ws-protocol-examples/src/index.ts
+++ b/typescript/ws-protocol-examples/src/index.ts
@@ -5,6 +5,7 @@ import ImageServer from "./examples/image-server";
 import McapPlay from "./examples/mcap-play";
 import ParamClient from "./examples/param-client";
 import ParamServer from "./examples/param-server";
+import PerfTestClient from "./examples/perf-test-client";
 import PublishClient from "./examples/publish-client";
 import SimpleClient from "./examples/simple-client";
 import Sysmon from "./examples/sysmon";
@@ -15,6 +16,7 @@ program.addCommand(McapPlay);
 program.addCommand(PublishClient);
 program.addCommand(SimpleClient);
 program.addCommand(Sysmon);
+program.addCommand(PerfTestClient);
 program.addCommand(ParamClient);
 program.addCommand(ParamServer);
 


### PR DESCRIPTION
**Public-Facing Changes**
- @foxglove/ws-protocol-examples: Add client to print channel statistics


**Description**
Adds a client that subscribes to all channels to collect statistics. These statistics are then printed to stdout when the connection is closed

The output is e.g. the following:

```
| topic                                       | Msgs rcvd | kB rcvd        |
|---------------------------------------------|-----------|----------------|
| /parameter_events                           | 4         | 0.62           |
| /rosout                                     | 39        | 7.59           |
| /camera/aligned_depth_to_color/camera_info  | 286       | 109.82         |
| /camera/depth/image_rect_raw                | 279       | 171437.69      |
| /camera/aligned_depth_to_color/color/points | 275       | 2703402.90     |
| /camera/aligned_depth_to_color/image_raw    | 283       | 173895.58      |
| /camera/color/camera_info                   | 286       | 109.82         |
| /camera/color/image_raw                     | 281       | 258989.83      |
| /camera/depth/camera_info                   | 285       | 109.44         |
| /tf_static                                  | 205       | 186.14         |

Total kB received: 3308249.432
```

