### PR TITLE
Mention base64 encoding in protocol specification

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -51,6 +51,9 @@
 
 Each JSON message must be an object containing a field called `op` which identifies the type of message.
 
+Additionally, each JSON message must encode any binary data fields (e.g.,
+protobuf or flatbuffer schemas) with base64.
+
 ### Server Info
 
 - This message is always sent to new clients upon connection.


### PR DESCRIPTION
Until I actually encountered errors in the code, I hadn't realized that base64 encoding was needed, partially because I don't use things that actually enforce unicode strings all that often. Since the string "base64" wasn't mentioned anywhere in the docs, at least bring it up to remind people that this is relevant.

I imagine other people might have similar questions.