### PR TITLE
ws-protocol-examples: Fix include order

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -5,8 +5,8 @@ import { Command } from "commander";
 import Debug from "debug";
 import { WebSocketServer } from "ws";
 
-import boxen from "../boxen";
 import { setupSigintHandler } from "./util/setupSigintHandler";
+import boxen from "../boxen";
 
 const log = Debug("foxglove:service-server");
 Debug.enable("foxglove:*");


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Fixes CI errors that got introduced with #350 

My local linter tells me the exact opposite tho:

![Screenshot from 2023-02-14 18-51-10](https://user-images.githubusercontent.com/9250155/218871660-2edc4503-9126-456a-8d1c-fd870b7495f9.png)

How can I bring CI and my local linter in line again? :thinking: 

