### PR TITLE
Clean up specification

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -321,20 +321,6 @@ Informs the client about services that are no longer available. Only supported i
 }
 ```
 
-### Client Publish
-
-- Sends a binary websocket message containing the raw messsage payload to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
-
-#### Message Data
-
-- Provides a raw message payload, encoded as advertised in the [Client Advertise](#client-advertise) operation.
-
-| Bytes           | Type    | Description     |
-| --------------- | ------- | --------------- |
-| 1               | opcode  | 0x01            |
-| 4               | uint32  | channel id      |
-| remaining bytes | uint8[] | message payload |
-
 ### Get Parameters
 
 Request one or more parameters. Only supported if the server previously declared that it has the `parameters` [capability](#server-info).
@@ -462,20 +448,6 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 | 1     | opcode | 0x02                    |
 | 8     | uint64 | timestamp (nanoseconds) |
 
-#### Service Call Request
-
-- Request to call a service that has been advertised by the server.
-- Only supported if the server previously declared the `services` [capability](#server-info).
-
-| Bytes             | Type    | Description                                                             |
-| ----------------- | ------- | ----------------------------------------------------------------------- |
-| 1                 | opcode  | 0x02                                                                    |
-| 4                 | uint32  | service id                                                              |
-| 4                 | uint32  | call id, a unique number to identify the corresponding service response |
-| 4                 | uint32  | encoding length                                                         |
-| _encoding length_ | char[]  | encoding, one of the encodings [supported by the server](#server-info)  |
-| remaining bytes   | uint8[] | request payload                                                         |
-
 ### Service Call Response
 
 - Provides the response to a previous [service call](#service-call-request).
@@ -489,3 +461,28 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 | 4                 | uint32  | encoding length                                       |
 | _encoding length_ | char[]  | encoding, same encoding that was used for the request |
 | remaining bytes   | uint8[] | response payload                                      |
+
+### Client Message Data
+
+- Sends a binary websocket message containing the raw messsage payload to the server. Note that the client is only allowed to publish messages if the server previously declared that it has the `clientPublish` [capability](#server-info).
+- The message payload is encoded as advertised in the [Client Advertise](#client-advertise) operation.
+
+| Bytes           | Type    | Description     |
+| --------------- | ------- | --------------- |
+| 1               | opcode  | 0x01            |
+| 4               | uint32  | channel id      |
+| remaining bytes | uint8[] | message payload |
+
+### Service Call Request
+
+- Request to call a service that has been advertised by the server.
+- Only supported if the server previously declared the `services` [capability](#server-info).
+
+| Bytes             | Type    | Description                                                             |
+| ----------------- | ------- | ----------------------------------------------------------------------- |
+| 1                 | opcode  | 0x02                                                                    |
+| 4                 | uint32  | service id                                                              |
+| 4                 | uint32  | call id, a unique number to identify the corresponding service response |
+| 4                 | uint32  | encoding length                                                         |
+| _encoding length_ | char[]  | encoding, one of the encodings [supported by the server](#server-info)  |
+| remaining bytes   | uint8[] | request payload                                                         |


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**

From #370:

> * [x] If you click on the link to "Message Data" in the TOC, it takes you to the client message data, not server message data.
> * [x] Additionally, the client message data op is listed under a heading called "JSON Messages". The heading called "Binary Messages" doesn't include the client message data.
> * [x] It looks like Service Call Request and Time have the same opcode (0x02).

It looks like that because it is currently not obvoius which messages are sent by the server and which by the client. In the TOC we divide between server and client messages, but the rest of the document does not since there it is divided into JSON and binary messages. IMO, the rest of the document and the heading order should be in the same order as the TOC.

> * [x] The Service Call Request heading is too small (wrong level)



Fixes #370
Fixes FG-2011
