### PR TITLE
Add channel field `schemaEncoding` for advertise operation

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -123,7 +123,7 @@ Each JSON message must be an object containing a field called `op` which identif
     > Note: Encodings currently supported by Foxglove Studio are `json`, `protobuf`, `ros1`, and `cdr` (ROS 2). For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
   - `schemaName`: string
   - `schema`: string
-    > Note: Foxglove Studio expects the schema to be in a format matching the `encoding`. For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
+    > Note: Foxglove Studio expects the schema to be in a format matching the `schemaEncoding` or alternatively the `encoding` if `schemaEncoding` is not specified. For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
   - `schemaEncoding`: string | undefined, type of encoding used for schema encoding. May be used if the schema encoding can't be uniquely deduced from the message encoding.
 
 #### Example

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -119,11 +119,12 @@ Each JSON message must be an object containing a field called `op` which identif
 - `channels`: array of:
   - `id`: number. The server may reuse ids when channels disappear and reappear, but only if the channel keeps the exact same topic, encoding, schemaName, and schema. Clients will use this unique id to cache schema info and deserialization routines.
   - `topic`: string
-  - `encoding`: string
+  - `encoding`: string, type of encoding used for message encoding
     > Note: Encodings currently supported by Foxglove Studio are `json`, `protobuf`, `ros1`, and `cdr` (ROS 2). For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
   - `schemaName`: string
   - `schema`: string
     > Note: Foxglove Studio expects the schema to be in a format matching the `encoding`. For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
+  - `schemaEncoding`: string | undefined, type of encoding used for schema encoding. May be used if the schema encoding can't be uniquely deduced from the message encoding.
 
 #### Example
 

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -32,6 +32,7 @@ export type Channel = {
   encoding: string;
   schemaName: string;
   schema: string;
+  schemaEncoding?: string;
 };
 export type Service = {
   id: number;


### PR DESCRIPTION
### Public-Facing Changes

- Add channel field `schemaEncoding` for advertise operation

### Description
Adds the optional channel field `schemaEncoding` which may be used if the schema encoding can't be uniquely deduced from the message encoding.

Example use case.
When message `encoding` is `cdr` (ROS 2), the schema can be specified using the `.msg` and `.idl` syntax.



