### PR TITLE
Achim/update cpp implementation

### DIFF
--- a/cpp/examples/src/example_server.cpp
+++ b/cpp/examples/src/example_server.cpp
@@ -15,6 +15,11 @@
 
 #include "foxglove/SceneUpdate.pb.h"
 
+namespace foxglove {
+template <>
+void Server<WebSocketNoTls>::setupTlsHandler() {}
+}  // namespace foxglove
+
 static uint64_t nanosecondsSinceEpoch() {
   return uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::system_clock::now().time_since_epoch())

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -3,10 +3,11 @@ project(FoxgloveWebSocket CXX)
 
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
+find_package(asio REQUIRED)
 
 add_library(foxglove_websocket src/parameter.cpp src/serialization.cpp)
 target_include_directories(foxglove_websocket PUBLIC include)
-target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
+target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp asio::asio)
 
 install(TARGETS foxglove_websocket)
 INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -22,6 +22,7 @@ class FoxgloveWebSocketConan(ConanFile):
     def requirements(self):
         self.requires("nlohmann_json/3.10.5")
         self.requires("websocketpp/0.8.2")
+        self.requires("asio/1.24.0")
 
     def configure(self):
         self.options["websocketpp"].asio = "standalone"

--- a/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstring>
 #include <stdint.h>
 #include <string>
@@ -13,6 +14,12 @@ constexpr char CAPABILITY_TIME[] = "time";
 constexpr char CAPABILITY_PARAMETERS[] = "parameters";
 constexpr char CAPABILITY_PARAMETERS_SUBSCRIBE[] = "parametersSubscribe";
 constexpr char CAPABILITY_SERVICES[] = "services";
+constexpr char CAPABILITY_CONNECTION_GRAPH[] = "connectionGraph";
+
+constexpr std::array<const char*, 5> DEFAULT_CAPABILITIES = {
+  CAPABILITY_CLIENT_PUBLISH, CAPABILITY_CONNECTION_GRAPH, CAPABILITY_PARAMETERS_SUBSCRIBE,
+  CAPABILITY_PARAMETERS,     CAPABILITY_SERVICES,
+};
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;

--- a/cpp/foxglove-websocket/include/foxglove/websocket/regex_utils.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/regex_utils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <algorithm>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace foxglove {
+
+inline bool isWhitelisted(const std::string& name, const std::vector<std::regex>& regexPatterns) {
+  return std::find_if(regexPatterns.begin(), regexPatterns.end(), [name](const auto& regex) {
+           return std::regex_match(name, regex);
+         }) != regexPatterns.end();
+}
+
+}  // namespace foxglove

--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
@@ -2,8 +2,10 @@
 
 #include <functional>
 #include <optional>
+#include <regex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common.hpp"
@@ -12,6 +14,8 @@
 namespace foxglove {
 
 constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
+
+using MapOfSets = std::unordered_map<std::string, std::unordered_set<std::string>>;
 
 struct ServerOptions {
   std::vector<std::string> capabilities;
@@ -23,6 +27,7 @@ struct ServerOptions {
   std::string keyfile = "";
   std::string sessionId;
   bool useCompression = false;
+  std::vector<std::regex> clientTopicWhitelistPatterns;
 };
 
 template <typename ConnectionHandle>
@@ -42,6 +47,7 @@ struct ServerHandlers {
                      ConnectionHandle)>
     parameterSubscriptionHandler;
   std::function<void(const ServiceRequest&, ConnectionHandle)> serviceRequestHandler;
+  std::function<void(bool)> subscribeConnectionGraphHandler;
 };
 
 template <typename ConnectionHandle>
@@ -69,6 +75,9 @@ public:
   virtual void broadcastTime(uint64_t timestamp) = 0;
   virtual void sendServiceResponse(ConnectionHandle clientHandle,
                                    const ServiceResponse& response) = 0;
+  virtual void updateConnectionGraph(const MapOfSets& publishedTopics,
+                                     const MapOfSets& subscribedTopics,
+                                     const MapOfSets& advertisedServices) = 0;
 
   virtual uint16_t getPort() = 0;
   virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;


### PR DESCRIPTION
### Public-Facing Changes
- Declares a dependency on asio (fixes CI build errors)
- Updates the cpp implementation to match the latest foxglove_bridge version

### Description
Not sure why the cpp builds were working before. In https://docs.websocketpp.org/faq.html it says:

> **Can WebSocket++ be used with standalone Asio**
>
> Yes. The process is the same as used with standalone Asio itself. Define ASIO_STANDALONE before including Asio or WebSocket++ headers. You will need to download a copy of the Asio headers separately (http://www.think-async.com/) and make sure they are in your build system's include path.

@jtbandes, I haven't yet created a 1.0.0 recipe on conan-center. If OK, I would just update the 1.0.0 tag after this PR got merged