### PR TITLE
cpp: Explicitly enable cpp17

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(asio REQUIRED)
 add_library(foxglove_websocket src/parameter.cpp src/serialization.cpp)
 target_include_directories(foxglove_websocket PUBLIC include)
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp asio::asio)
+set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 install(TARGETS foxglove_websocket)
 INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
I though that conan would automaticlaly do this, but apparently this is not the case: https://github.com/conan-io/conan-center-index/pull/16500#issuecomment-1463916745
Anyway, it's still a good practice to enable it explicitly in case it is build without conan