### PR TITLE
Add mcap-record example

### DIFF
--- a/typescript/ws-protocol-examples/README.md
+++ b/typescript/ws-protocol-examples/README.md
@@ -49,6 +49,12 @@ Run a client that advertises the `/chatter` topic and publishes messages to it w
 $ npx @foxglove/ws-protocol-examples@latest publish-client -e json ws://localhost:8765
 ```
 
+Connect to a server and record message data into an [MCAP](https://mcap.dev) file:
+
+```
+$ npx @foxglove/ws-protocol-examples@latest mcap-record ws://localhost:8765 -o <file.mcap>
+```
+
 ## Development
 
 This package lives inside a monorepo that uses [yarn workspaces](https://yarnpkg.com/features/workspaces), so most commands (other than `yarn install`) should be prefixed with `yarn workspace @foxglove/ws-protocol-examples ...`.

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol-examples",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Foxglove WebSocket protocol examples",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol-examples/src/examples/mcap-record.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-record.ts
@@ -106,7 +106,6 @@ async function main(address: string, options: { output: string }): Promise<void>
       return;
     }
     await new Promise<void>((resolve) => {
-      const mcapChannelsByWsChannel = new Map<WsChannelId, McapChannelId>();
       const wsChannelsByMcapChannel = new Map<McapChannelId, WsChannelId>();
       const subscriptionsById = new Map<
         SubscriptionId,
@@ -177,7 +176,6 @@ async function main(address: string, options: { output: string }): Promise<void>
               messageEncoding: channel.encoding,
               metadata: new Map(),
             })) as McapChannelId;
-            mcapChannelsByWsChannel.set(channel.id as WsChannelId, mcapChannelId);
             wsChannelsByMcapChannel.set(mcapChannelId, channel.id as WsChannelId);
 
             log("subscribing to %s", channel.topic);

--- a/typescript/ws-protocol-examples/src/examples/mcap-record.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-record.ts
@@ -1,0 +1,233 @@
+import * as Zstd from "@foxglove/wasm-zstd";
+import { FoxgloveClient } from "@foxglove/ws-protocol";
+import { IWritable, McapWriter } from "@mcap/core";
+import { Command } from "commander";
+import Debug from "debug";
+import fs, { FileHandle } from "fs/promises";
+import path from "path";
+import { WebSocket } from "ws";
+
+const log = Debug("foxglove:mcap-record");
+Debug.enable("foxglove:*");
+
+type McapChannelId = number & { __brand: "McapChannelId" };
+type WsChannelId = number & { __brand: "WsChannelId" };
+type SubscriptionId = number & { __brand: "SubscriptionId" };
+
+// Mcap IWritable interface for nodejs FileHandle
+class FileHandleWritable implements IWritable {
+  private handle: FileHandle;
+  private totalBytesWritten = 0;
+
+  constructor(handle: FileHandle) {
+    this.handle = handle;
+  }
+
+  async write(buffer: Uint8Array): Promise<void> {
+    const written = await this.handle.write(buffer);
+    this.totalBytesWritten += written.bytesWritten;
+  }
+
+  position(): bigint {
+    return BigInt(this.totalBytesWritten);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/promise-function-async
+function delay(durationMs: number) {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function waitForServer(
+  address: string,
+  signal: AbortSignal,
+): Promise<FoxgloveClient | undefined> {
+  log("connecting to %s", address);
+  while (!signal.aborted) {
+    const maybeClient = await new Promise<FoxgloveClient | undefined>((resolve) => {
+      const ws = new WebSocket(address, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]);
+      const client = new FoxgloveClient({ ws });
+      const onClose = (event: CloseEvent) => {
+        log(
+          "connection failed, code=%s reason=%s wasClean=%s",
+          event.code,
+          event.reason,
+          event.wasClean,
+        );
+        resolve(undefined);
+      };
+      client.on("open", () => {
+        client.off("close", onClose);
+        signal.addEventListener("abort", () => {
+          client.close();
+        });
+        resolve(client);
+      });
+      client.on("close", onClose);
+    });
+    if (maybeClient) {
+      return maybeClient;
+    }
+    log("trying again in 5 seconds...");
+    await delay(5000);
+  }
+  return undefined;
+}
+
+async function main(address: string, options: { output: string }): Promise<void> {
+  await Zstd.isLoaded;
+  await fs.mkdir(path.dirname(options.output), { recursive: true });
+  const fileHandle = await fs.open(options.output, "w");
+  const fileHandleWritable = new FileHandleWritable(fileHandle);
+  const textEncoder = new TextEncoder();
+
+  const writer = new McapWriter({
+    writable: fileHandleWritable,
+    compressChunk: (data) => ({
+      compression: "zstd",
+      compressedData: Zstd.compress(data, 19),
+    }),
+  });
+
+  await writer.start({
+    profile: "",
+    library: "mcap-record",
+  });
+
+  const controller = new AbortController();
+  process.on("SIGINT", () => {
+    log("shutting down...");
+    controller.abort();
+  });
+
+  try {
+    const client = await waitForServer(address, controller.signal);
+    if (!client) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const mcapChannelsByWsChannel = new Map<WsChannelId, McapChannelId>();
+      const wsChannelsByMcapChannel = new Map<McapChannelId, WsChannelId>();
+      const subscriptionsById = new Map<
+        SubscriptionId,
+        { messageCount: number; mcapChannelId: McapChannelId }
+      >();
+
+      client.on("serverInfo", (event) => {
+        log(event);
+      });
+      client.on("status", (event) => {
+        log(event);
+      });
+      client.on("error", (err) => {
+        log("server error: %o", err);
+      });
+
+      client.on("advertise", (newChannels) => {
+        void Promise.all(
+          newChannels.map(async (channel) => {
+            let schemaEncoding = channel.schemaEncoding;
+            if (schemaEncoding == undefined) {
+              switch (channel.encoding) {
+                case "json":
+                  schemaEncoding = "jsonschema";
+                  break;
+                case "protobuf":
+                  schemaEncoding = "protobuf";
+                  break;
+                case "flatbuffer":
+                  schemaEncoding = "flatbuffer";
+                  break;
+                case "ros1":
+                  schemaEncoding = "ros1msg";
+                  break;
+                case "ros2":
+                  schemaEncoding = "ros2msg";
+                  break;
+                default:
+                  log(
+                    "unable to infer schema encoding from message encoding %s on topic %s, messages will be recorded without schema",
+                    channel.encoding,
+                    channel.topic,
+                  );
+                  break;
+              }
+            }
+            let schemaData: Uint8Array | undefined;
+            switch (schemaEncoding) {
+              case "jsonschema":
+              case "ros1msg":
+              case "ros2msg":
+                schemaData = textEncoder.encode(channel.schema);
+                break;
+              case "protobuf":
+              case "flatbuffer":
+                schemaData = Buffer.from(channel.schema, "base64");
+                break;
+              default:
+                log(
+                  "unknown schema encoding %s, messages will be recorded without schema",
+                  schemaEncoding,
+                );
+                break;
+              case undefined:
+                break;
+            }
+            const schemaId =
+              schemaData != undefined && schemaEncoding != undefined
+                ? await writer.registerSchema({
+                    name: channel.schemaName,
+                    encoding: schemaEncoding,
+                    data: schemaData,
+                  })
+                : 0;
+            const mcapChannelId = (await writer.registerChannel({
+              schemaId,
+              topic: channel.topic,
+              messageEncoding: channel.encoding,
+              metadata: new Map(),
+            })) as McapChannelId;
+            mcapChannelsByWsChannel.set(channel.id as WsChannelId, mcapChannelId);
+            wsChannelsByMcapChannel.set(mcapChannelId, channel.id as WsChannelId);
+
+            log("subscribing to %s", channel.topic);
+            const subscriptionId = client.subscribe(channel.id) as SubscriptionId;
+            subscriptionsById.set(subscriptionId, { messageCount: 0, mcapChannelId });
+          }),
+        );
+      });
+      client.on("message", (event) => {
+        const subscription = subscriptionsById.get(event.subscriptionId as SubscriptionId);
+        if (subscription == undefined) {
+          log("received message for unknown subscription %s", event.subscriptionId);
+          return;
+        }
+        void writer.addMessage({
+          channelId: subscription.mcapChannelId,
+          sequence: subscription.messageCount++,
+          logTime: BigInt(Date.now()) * 1_000_000n,
+          publishTime: event.timestamp,
+          data: new Uint8Array(event.data.buffer, event.data.byteOffset, event.data.byteLength),
+        });
+      });
+
+      client.on("close", (event) => {
+        log(
+          "server disconnected, code=%s reason=%s wasClean=%s",
+          event.code,
+          event.reason,
+          event.wasClean,
+        );
+        resolve();
+      });
+    });
+  } finally {
+    await writer.end();
+  }
+}
+
+export default new Command("mcap-record")
+  .description("connect to a WebSocket server and record an MCAP file")
+  .argument("<address>", "WebSocket address, e.g. ws://localhost:8765")
+  .option("-o, --output <file>", "path to write MCAP file")
+  .action(main);

--- a/typescript/ws-protocol-examples/src/index.ts
+++ b/typescript/ws-protocol-examples/src/index.ts
@@ -3,6 +3,7 @@ import { program } from "commander";
 
 import ImageServer from "./examples/image-server";
 import McapPlay from "./examples/mcap-play";
+import McapRecord from "./examples/mcap-record";
 import ParamClient from "./examples/param-client";
 import ParamServer from "./examples/param-server";
 import PerfTestClient from "./examples/perf-test-client";
@@ -15,6 +16,7 @@ import Sysmon from "./examples/sysmon";
 program.name("ws-protocol-examples");
 program.addCommand(ImageServer);
 program.addCommand(McapPlay);
+program.addCommand(McapRecord);
 program.addCommand(PublishClient);
 program.addCommand(SimpleClient);
 program.addCommand(Sysmon);


### PR DESCRIPTION
### Public-Facing Changes

Added `npx @foxglove/ws-protocol-examples@latest mcap-record` which connects to a WebSocket server and records data into an MCAP file.

### Description

