### PR TITLE
Update allowed types for parameter values

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -170,7 +170,7 @@ Informs the client about parameters. Only supported if the server declares the `
 - `op`: string `"parameterValues"`
 - `parameters`: array of:
   - `name`: string, name of the parameter
-  - `value`: number | boolean | string | number[] | boolean[] | string[]
+  - `value`: ParameterValue, where ParameterValue is of type number | boolean | string | ParameterValue[] | { [key: string]: ParameterValue } | undefined.
   - `type`: "byte_array" | undefined. If the type is `byte_array`, `value` shall be interpreted as base64 encoded string.
 - `id`: string | undefined. Only set when the [getParameters](#get-parameters) or [setParameters](#set-parameters) request's `id` field was set
 

--- a/typescript/ws-protocol/package.json
+++ b/typescript/ws-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Foxglove Studio WebSocket protocol",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -192,9 +192,16 @@ export type ClientPublish = {
   channel: ClientChannel;
   data: DataView;
 };
+export type ParameterValue =
+  | undefined
+  | number
+  | boolean
+  | string
+  | { [key: string]: ParameterValue }
+  | ParameterValue[];
 export type Parameter = {
   name: string;
-  value: number | boolean | string | number[] | boolean[] | string[] | undefined;
+  value: ParameterValue;
   type?: "byte_array";
 };
 


### PR DESCRIPTION
### Public-Facing Changes

- Update allowed types for parameter values

### Description
Allows parameter values to be of type `{ [key: string]: ParameterValue }` or an array of that which can be the case for ROS1 parameters.