### PR TITLE
Python: Disable compression by default, allow specifying server kwargs

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-websocket
-version = 0.1.0
+version = 0.1.1
 description = Foxglove WebSocket server
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -163,7 +163,7 @@ class FoxgloveServer:
         metadata: Optional[Mapping[str, str]] = None,
         session_id: Optional[str] = None,
         logger: logging.Logger = _get_default_logger(),
-        server_kwargs: Dict[str, Any] = { "compression": None },
+        server_kwargs: Dict[str, Any] = {"compression": None},
     ):
         self.host = host
         self.port = port
@@ -224,7 +224,7 @@ class FoxgloveServer:
                 self.host,
                 self.port,
                 subprotocols=[Subprotocol("foxglove.websocket.v1")],
-                **self._server_kwargs
+                **self._server_kwargs,
             )
             self._opened.set_result(server)
         except asyncio.CancelledError:

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -163,6 +163,7 @@ class FoxgloveServer:
         metadata: Optional[Mapping[str, str]] = None,
         session_id: Optional[str] = None,
         logger: logging.Logger = _get_default_logger(),
+        server_kwargs: Dict[str, Any] = { "compression": None },
     ):
         self.host = host
         self.port = port
@@ -178,6 +179,7 @@ class FoxgloveServer:
         self._next_service_id = ServiceId(0)
         self._subscribed_params = set([])
         self._logger = logger
+        self._server_kwargs = server_kwargs
         self._listener = None
         self._opened = asyncio.get_running_loop().create_future()
 
@@ -222,6 +224,7 @@ class FoxgloveServer:
                 self.host,
                 self.port,
                 subprotocols=[Subprotocol("foxglove.websocket.v1")],
+                **self._server_kwargs
             )
             self._opened.set_result(server)
         except asyncio.CancelledError:


### PR DESCRIPTION
### Public-Facing Changes

- Python: Disable compression by default, allow specifying server kwargs

### Description
Allows specifying [websockets.server.serve(...) ](https://websockets.readthedocs.io/en/stable/reference/asyncio/server.html#websockets.server.serve)keyword arguments and disables compression (`compression=None`) by default

Fixes #443 