### PR TITLE
Extend spec to allow fetching of assets

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -505,15 +505,15 @@ Fetch an asset from the server. Only supported if the server previously declared
 #### Fields
 
 - `op`: string `"fetchAsset"`
-- `assetId`: string, unique identifier to locate the asset
-- `requestId`: number, unique 32-bit unsigned integer which is to be included in the response
+- `assetURI`: string, uniform resource identifier to locate a single asset
+- `requestId`: number, unique 32-bit unsigned integer which is to be included in the [response](#fetch-asset-response)
 
 #### Example
 
 ```json
 {
   "op": "fetchAsset",
-  "assetId": "file:///foo/bar.txt",
+  "assetURI": "package://foo/robot.urdf",
   "requestId": 123
 }
 ```
@@ -566,14 +566,16 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 - Response to a [fetch asset](#fetch-asset) request
 - Only supported if the server previously declared the `assets` [capability](#server-info).
 
-| Bytes           | Type             | Description                                                                                                             |
-| --------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| 1               | opcode           | 0x04                                                                                                                    |
-| 4               | uint32           | request id, as given in the corresponding [request](#fetch-asset)                                                       |
-| 1               | uint8            | status enum, `0` for success and `1` for error. Values `>1` are reserved for future use                                 |
-| 4 + N           | uint32 + char[N] | error message, empty if `status == 0`                                                                                   |
-| 4 + M           | uint32 + char[M] | asset [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), empty if `status != 0` |
-| remaining bytes | uint8[]          | asset data (file contents), empty if `status != 0`                                                                      |
+| Bytes                  | Type    | Description                                                                                                             |
+| ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 1                      | opcode  | 0x04                                                                                                                    |
+| 4                      | uint32  | request id, as given in the corresponding [request](#fetch-asset)                                                       |
+| 1                      | uint8   | status enum, `0` for success and `1` for error. Values `>1` are reserved for future use                                 |
+| 4                      | uint32  | error message length                                                                                                    |
+| _error message length_ | char[]  | error message, empty if `status == 0`                                                                                   |
+| 4                      | uint32  | media type length                                                                                                       |
+| _media type length_    | char[]  | asset [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), empty if `status != 0` |
+| remaining bytes        | uint8[] | asset data (file contents), empty if `status != 0`                                                                      |
 
 ### Client Message Data
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -566,13 +566,13 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 - Response to a [fetch asset](#fetch-asset) request
 - Only supported if the server previously declared the `assets` [capability](#server-info).
 
-| Bytes           | Type             | Description                                                                                                                                                   |
-| --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1               | opcode           | 0x04                                                                                                                                                          |
-| 4               | uint32           | request id, as given in the corresponding [request](#fetch-asset)                                                                                             |
-| 1               | uint8            | status, value is `1` if the asset was fetched succesfully, all other values are error codes                                                                   |
-| 4 + N           | uint32 + char[N] | [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the asset (if `status == 1`) or error message (if `status != 1`) |
-| remaining bytes | uint8[]          | asset data (file contents, empty if `status != 1`)                                                                                                            |
+| Bytes           | Type             | Description                                                                                                                                              |
+| --------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1               | opcode           | 0x04                                                                                                                                                     |
+| 4               | uint32           | request id, as given in the corresponding [request](#fetch-asset)                                                                                        |
+| 1               | uint8            | status enum, `0` for success and `1` for error. Values `>1` are reserved for future use                                                                  |
+| 4 + N           | uint32 + char[N] | asset [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), if `status == 0` <br /> error message, if `status == 1` |
+| remaining bytes | uint8[]          | asset data (file contents), empty if `status != 0`                                                                                                       |
 
 ### Client Message Data
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -573,8 +573,6 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 | 1                      | uint8   | status enum, `0` for success and `1` for error. Values `>1` are reserved for future use                                 |
 | 4                      | uint32  | error message length                                                                                                    |
 | _error message length_ | char[]  | error message, empty if `status == 0`                                                                                   |
-| 4                      | uint32  | media type length                                                                                                       |
-| _media type length_    | char[]  | asset [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), empty if `status != 0` |
 | remaining bytes        | uint8[] | asset data (file contents), empty if `status != 0`                                                                      |
 
 ### Client Message Data

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -505,7 +505,7 @@ Fetch an asset from the server. Only supported if the server previously declared
 #### Fields
 
 - `op`: string `"fetchAsset"`
-- `assetURI`: string, uniform resource identifier to locate a single asset
+- `assetUri`: string, uniform resource identifier to locate a single asset
 - `requestId`: number, unique 32-bit unsigned integer which is to be included in the [response](#fetch-asset-response)
 
 #### Example
@@ -513,7 +513,7 @@ Fetch an asset from the server. Only supported if the server previously declared
 ```json
 {
   "op": "fetchAsset",
-  "assetURI": "package://foo/robot.urdf",
+  "assetUri": "package://foo/robot.urdf",
   "requestId": 123
 }
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -34,6 +34,7 @@
 - [Unadvertise Services](#unadvertise-services) (json)
 - [Service Call Response](#service-call-response) (binary)
 - [Connection Graph Update](#connection-graph-update) (json)
+- [Asset](#asset) (binary)
 
 ### Sent by client
 
@@ -49,6 +50,7 @@
 - [Service Call Request](#service-call-request) (binary)
 - [Subscribe connection graph updates](#subscribe-connection-graph-updates) (json)
 - [Unubscribe connection graph updates](#unsubscribe-connection-graph-updates) (json)
+- [Fetch asset](#fetch-asset) (json)
 
 ## JSON messages
 
@@ -69,6 +71,7 @@ Each JSON message must be an object containing a field called `op` which identif
   - `time`: The server may publish binary [time](#time) messages
   - `services`: Allow clients to call services
   - `connectionGraph`: Allow clients to subscribe to updates to the connection graph
+  - `assets`: Allow clients to fetch assets
 - `supportedEncodings`: array of strings | informing the client about which encodings may be used for client-side publishing or service call requests/responses. Only set if client publishing or services are supported.
 - `metadata`: optional map of key-value pairs
 - `sessionId`: optional string. Allows the client to understand if the connection is a re-connection or if it is connecting to a new server instance. This can for example be a timestamp or a UUID.
@@ -495,6 +498,26 @@ Unsubscribe from [connection graph updates](#connection-graph-update). Only supp
 }
 ```
 
+### Fetch asset
+
+Fetch an asset from the server. Only supported if the server previously declared that it has the `assets` [capability](#server-info).
+
+#### Fields
+
+- `op`: string `"fetchAsset"`
+- `uri`: string, unique identifier to locate the asset
+- `requestId`: number, unique 32-bit unsigned integer which is to be included in the response
+
+#### Example
+
+```json
+{
+  "op": "fetchAsset",
+  "uri": "file:///foo/bar.txt",
+  "requestId": 123
+}
+```
+
 ## Binary messages
 
 All binary messages must start with a 1-byte opcode identifying the type of message. The interpretation of the remaining bytes depends on the opcode.
@@ -537,6 +560,20 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 | 4                 | uint32  | encoding length                                       |
 | _encoding length_ | char[]  | encoding, same encoding that was used for the request |
 | remaining bytes   | uint8[] | response payload                                      |
+
+### Asset
+
+- Response to a [fetch asset](#fetch-asset) request if the asset was found
+- Only supported if the server previously declared the `assets` [capability](#server-info).
+
+| Bytes               | Type    | Description                                                                                            |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| 1                   | opcode  | 0x04                                                                                                   |
+| 4                   | uint32  | request id, as given in the corresponding [request](#fetch-asset)                                      |
+| 8                   | uint64  | Last modified time of the asset (nanoseconds)                                                          |
+| 4                   | uint32  | media type length                                                                                      |
+| _media type length_ | char[]  | [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the asset |
+| remaining bytes     | uint8[] | asset data (file contents)                                                                             |
 
 ### Client Message Data
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -505,7 +505,7 @@ Fetch an asset from the server. Only supported if the server previously declared
 #### Fields
 
 - `op`: string `"fetchAsset"`
-- `assetUri`: string, uniform resource identifier to locate a single asset
+- `uri`: string, uniform resource identifier to locate a single asset
 - `requestId`: number, unique 32-bit unsigned integer which is to be included in the [response](#fetch-asset-response)
 
 #### Example
@@ -513,7 +513,7 @@ Fetch an asset from the server. Only supported if the server previously declared
 ```json
 {
   "op": "fetchAsset",
-  "assetUri": "package://foo/robot.urdf",
+  "uri": "package://foo/robot.urdf",
   "requestId": 123
 }
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -561,18 +561,19 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 | _encoding length_ | char[]  | encoding, same encoding that was used for the request |
 | remaining bytes   | uint8[] | response payload                                      |
 
-### Asset
+### Fetch Asset Response
 
 - Response to a [fetch asset](#fetch-asset) request
 - Only supported if the server previously declared the `assets` [capability](#server-info).
 
-| Bytes           | Type             | Description                                                                                                                                              |
-| --------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1               | opcode           | 0x04                                                                                                                                                     |
-| 4               | uint32           | request id, as given in the corresponding [request](#fetch-asset)                                                                                        |
-| 1               | uint8            | status enum, `0` for success and `1` for error. Values `>1` are reserved for future use                                                                  |
-| 4 + N           | uint32 + char[N] | asset [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), if `status == 0` <br /> error message, if `status == 1` |
-| remaining bytes | uint8[]          | asset data (file contents), empty if `status != 0`                                                                                                       |
+| Bytes           | Type             | Description                                                                                                             |
+| --------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 1               | opcode           | 0x04                                                                                                                    |
+| 4               | uint32           | request id, as given in the corresponding [request](#fetch-asset)                                                       |
+| 1               | uint8            | status enum, `0` for success and `1` for error. Values `>1` are reserved for future use                                 |
+| 4 + N           | uint32 + char[N] | error message, empty if `status == 0`                                                                                   |
+| 4 + M           | uint32 + char[M] | asset [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), empty if `status != 0` |
+| remaining bytes | uint8[]          | asset data (file contents), empty if `status != 0`                                                                      |
 
 ### Client Message Data
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -505,7 +505,7 @@ Fetch an asset from the server. Only supported if the server previously declared
 #### Fields
 
 - `op`: string `"fetchAsset"`
-- `uri`: string, unique identifier to locate the asset
+- `assetId`: string, unique identifier to locate the asset
 - `requestId`: number, unique 32-bit unsigned integer which is to be included in the response
 
 #### Example
@@ -513,7 +513,7 @@ Fetch an asset from the server. Only supported if the server previously declared
 ```json
 {
   "op": "fetchAsset",
-  "uri": "file:///foo/bar.txt",
+  "assetId": "file:///foo/bar.txt",
   "requestId": 123
 }
 ```
@@ -563,17 +563,16 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 
 ### Asset
 
-- Response to a [fetch asset](#fetch-asset) request if the asset was found
+- Response to a [fetch asset](#fetch-asset) request
 - Only supported if the server previously declared the `assets` [capability](#server-info).
 
-| Bytes               | Type    | Description                                                                                            |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| 1                   | opcode  | 0x04                                                                                                   |
-| 4                   | uint32  | request id, as given in the corresponding [request](#fetch-asset)                                      |
-| 8                   | uint64  | Last modified time of the asset (nanoseconds)                                                          |
-| 4                   | uint32  | media type length                                                                                      |
-| _media type length_ | char[]  | [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the asset |
-| remaining bytes     | uint8[] | asset data (file contents)                                                                             |
+| Bytes           | Type             | Description                                                                                                                                                   |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1               | opcode           | 0x04                                                                                                                                                          |
+| 4               | uint32           | request id, as given in the corresponding [request](#fetch-asset)                                                                                             |
+| 1               | uint8            | status, value is `1` if the asset was fetched succesfully, all other values are error codes                                                                   |
+| 4 + N           | uint32 + char[N] | [media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the asset (if `status == 1`) or error message (if `status != 1`) |
+| remaining bytes | uint8[]          | asset data (file contents, empty if `status != 1`)                                                                                                            |
 
 ### Client Message Data
 

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -238,8 +238,8 @@ export default class FoxgloveClient {
     this.send({ op: "unsubscribeConnectionGraph" });
   }
 
-  fetchAsset(assetId: string, requestId: number): void {
-    this.send({ op: "fetchAsset", assetId, requestId });
+  fetchAsset(assetURI: string, requestId: number): void {
+    this.send({ op: "fetchAsset", assetURI, requestId });
   }
 
   /**

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -39,7 +39,7 @@ type EventTypes = {
   parameterValues: (event: ParameterValues) => void;
   serviceCallResponse: (event: ServiceCallResponse) => void;
   connectionGraphUpdate: (event: ConnectionGraphUpdate) => void;
-  asset: (event: FetchAssetResponse) => void;
+  fetchAssetResponse: (event: FetchAssetResponse) => void;
 };
 
 const textEncoder = new TextEncoder();
@@ -141,8 +141,8 @@ export default class FoxgloveClient {
           this.emitter.emit("serviceCallResponse", message);
           return;
 
-        case BinaryOpcode.ASSET:
-          this.emitter.emit("asset", message);
+        case BinaryOpcode.FETCH_ASSET_RESPONSE:
+          this.emitter.emit("fetchAssetResponse", message);
           return;
       }
       this.emitter.emit(

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -3,6 +3,7 @@ import EventEmitter from "eventemitter3";
 import { ChannelId, MessageData, ServerInfo, StatusMessage } from ".";
 import { parseServerMessage } from "./parse";
 import {
+  Asset,
   BinaryOpcode,
   Channel,
   ClientBinaryOpcode,
@@ -38,6 +39,7 @@ type EventTypes = {
   parameterValues: (event: ParameterValues) => void;
   serviceCallResponse: (event: ServiceCallResponse) => void;
   connectionGraphUpdate: (event: ConnectionGraphUpdate) => void;
+  asset: (event: Asset) => void;
 };
 
 const textEncoder = new TextEncoder();
@@ -138,6 +140,10 @@ export default class FoxgloveClient {
         case BinaryOpcode.SERVICE_CALL_RESPONSE:
           this.emitter.emit("serviceCallResponse", message);
           return;
+
+        case BinaryOpcode.ASSET:
+          this.emitter.emit("asset", message);
+          return;
       }
       this.emitter.emit(
         "error",
@@ -230,6 +236,10 @@ export default class FoxgloveClient {
 
   unsubscribeConnectionGraph(): void {
     this.send({ op: "unsubscribeConnectionGraph" });
+  }
+
+  fetchAsset(uri: string, requestId: number): void {
+    this.send({ op: "fetchAsset", uri, requestId });
   }
 
   /**

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -3,7 +3,6 @@ import EventEmitter from "eventemitter3";
 import { ChannelId, MessageData, ServerInfo, StatusMessage } from ".";
 import { parseServerMessage } from "./parse";
 import {
-  Asset,
   BinaryOpcode,
   Channel,
   ClientBinaryOpcode,
@@ -11,6 +10,7 @@ import {
   ClientChannelId,
   ClientMessage,
   ConnectionGraphUpdate,
+  FetchAssetResponse,
   IWebSocket,
   Parameter,
   ParameterValues,
@@ -39,7 +39,7 @@ type EventTypes = {
   parameterValues: (event: ParameterValues) => void;
   serviceCallResponse: (event: ServiceCallResponse) => void;
   connectionGraphUpdate: (event: ConnectionGraphUpdate) => void;
-  asset: (event: Asset) => void;
+  asset: (event: FetchAssetResponse) => void;
 };
 
 const textEncoder = new TextEncoder();

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -238,8 +238,8 @@ export default class FoxgloveClient {
     this.send({ op: "unsubscribeConnectionGraph" });
   }
 
-  fetchAsset(uri: string, requestId: number): void {
-    this.send({ op: "fetchAsset", uri, requestId });
+  fetchAsset(assetId: string, requestId: number): void {
+    this.send({ op: "fetchAsset", assetId, requestId });
   }
 
   /**

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -238,8 +238,8 @@ export default class FoxgloveClient {
     this.send({ op: "unsubscribeConnectionGraph" });
   }
 
-  fetchAsset(assetUri: string, requestId: number): void {
-    this.send({ op: "fetchAsset", assetUri, requestId });
+  fetchAsset(uri: string, requestId: number): void {
+    this.send({ op: "fetchAsset", uri, requestId });
   }
 
   /**

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -238,8 +238,8 @@ export default class FoxgloveClient {
     this.send({ op: "unsubscribeConnectionGraph" });
   }
 
-  fetchAsset(assetURI: string, requestId: number): void {
-    this.send({ op: "fetchAsset", assetURI, requestId });
+  fetchAsset(assetUri: string, requestId: number): void {
+    this.send({ op: "fetchAsset", assetUri, requestId });
   }
 
   /**

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -513,9 +513,9 @@ describe("FoxgloveServer", () => {
     ],
   ])(
     "should send fetch asset request and receive appropriate response for %s",
-    async (timePrimitive: string, assetURI: string, response: FetchAssetResponse) => {
+    async (timePrimitive: string, assetUri: string, response: FetchAssetResponse) => {
       expect(timePrimitive).toEqual(timePrimitive);
-      expect(assetURI).toEqual(assetURI);
+      expect(assetUri).toEqual(assetUri);
       expect(response).toEqual(response);
 
       const server = new FoxgloveServer({
@@ -534,7 +534,7 @@ describe("FoxgloveServer", () => {
 
         const request = {
           op: "fetchAsset",
-          assetURI,
+          assetUri,
           requestId: response.requestId,
         };
         send(JSON.stringify(request));

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -512,9 +512,9 @@ describe("FoxgloveServer", () => {
     ],
   ])(
     "should send fetch asset request and receive appropriate response for %s",
-    async (timePrimitive: string, assetUri: string, response: FetchAssetResponse) => {
+    async (timePrimitive: string, uri: string, response: FetchAssetResponse) => {
       expect(timePrimitive).toEqual(timePrimitive);
-      expect(assetUri).toEqual(assetUri);
+      expect(uri).toEqual(uri);
       expect(response).toEqual(response);
 
       const server = new FoxgloveServer({
@@ -533,7 +533,7 @@ describe("FoxgloveServer", () => {
 
         const request = {
           op: "fetchAsset",
-          assetUri,
+          uri,
           requestId: response.requestId,
         };
         send(JSON.stringify(request));

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -504,7 +504,7 @@ describe("FoxgloveServer", () => {
         op: BinaryOpcode.FETCH_ASSET_RESPONSE,
         requestId: 456,
         status: FetchAssetStatus.ERROR,
-        errorMsg: "asset not found",
+        error: "asset not found",
       },
     ],
   ])(
@@ -540,7 +540,7 @@ describe("FoxgloveServer", () => {
         expect(receivedRequest).toEqual(request);
         server.sendFetchAssetResponse(response, connection as IWebSocket);
 
-        const errorMsg = response.status === FetchAssetStatus.ERROR ? response.errorMsg : "";
+        const errorMsg = response.status === FetchAssetStatus.ERROR ? response.error : "";
         const data =
           response.status === FetchAssetStatus.SUCCESS
             ? response.data

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -497,7 +497,6 @@ describe("FoxgloveServer", () => {
         requestId: 123,
         errorMsg: "",
         status: FetchAssetStatus.SUCCESS,
-        mediaType: "text/xml",
         data: new DataView(new Uint8Array([4, 5, 6]).buffer),
       } as FetchAssetSuccessResponse,
     ],
@@ -545,7 +544,6 @@ describe("FoxgloveServer", () => {
         server.sendFetchAssetResponse(response, connection as IWebSocket);
 
         const errorMsg = response.status === FetchAssetStatus.ERROR ? response.errorMsg : "";
-        const mediaType = response.status === FetchAssetStatus.SUCCESS ? response.mediaType : "";
         const data =
           response.status === FetchAssetStatus.SUCCESS
             ? response.data
@@ -558,8 +556,6 @@ describe("FoxgloveServer", () => {
             response.status,
             ...uint32LE(errorMsg.length),
             ...new TextEncoder().encode(errorMsg),
-            ...uint32LE(mediaType.length),
-            ...new TextEncoder().encode(mediaType),
             ...Buffer.from(data.buffer),
           ]),
         );

--- a/typescript/ws-protocol/src/FoxgloveServer.test.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.test.ts
@@ -5,10 +5,8 @@ import {
   BinaryOpcode,
   ClientBinaryOpcode,
   ClientPublish,
-  FetchAssetErrorResponse,
   FetchAssetResponse,
   FetchAssetStatus,
-  FetchAssetSuccessResponse,
   IWebSocket,
   Parameter,
   ServerCapability,
@@ -488,17 +486,16 @@ describe("FoxgloveServer", () => {
     close();
   });
 
-  it.each([
+  it.each<[string, string, FetchAssetResponse]>([
     [
       "existing asset",
       "package://foo/bar.urdf",
       {
         op: BinaryOpcode.FETCH_ASSET_RESPONSE,
         requestId: 123,
-        errorMsg: "",
         status: FetchAssetStatus.SUCCESS,
         data: new DataView(new Uint8Array([4, 5, 6]).buffer),
-      } as FetchAssetSuccessResponse,
+      },
     ],
     [
       "non existing asset",
@@ -508,7 +505,7 @@ describe("FoxgloveServer", () => {
         requestId: 456,
         status: FetchAssetStatus.ERROR,
         errorMsg: "asset not found",
-      } as FetchAssetErrorResponse,
+      },
     ],
   ])(
     "should send fetch asset request and receive appropriate response for %s",

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -617,7 +617,7 @@ export default class FoxgloveServer {
    */
   sendFetchAssetResponse(response: FetchAssetResponse, connection: IWebSocket): void {
     const isSuccess = response.status === FetchAssetStatus.SUCCESS;
-    const errorMsg = textEncoder.encode(isSuccess ? "" : response.errorMsg);
+    const errorMsg = textEncoder.encode(isSuccess ? "" : response.error);
     const dataLength = isSuccess ? response.data.byteLength : 0;
     const msg = new Uint8Array(1 + 4 + 1 + 4 + errorMsg.length + dataLength);
     const view = new DataView(msg.buffer, msg.byteOffset, msg.byteLength);

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -618,9 +618,8 @@ export default class FoxgloveServer {
   sendFetchAssetResponse(response: FetchAssetResponse, connection: IWebSocket): void {
     const isSuccess = response.status === FetchAssetStatus.SUCCESS;
     const errorMsg = textEncoder.encode(isSuccess ? "" : response.errorMsg);
-    const mediaType = textEncoder.encode(isSuccess ? response.mediaType : "");
     const dataLength = isSuccess ? response.data.byteLength : 0;
-    const msg = new Uint8Array(1 + 4 + 1 + 4 + errorMsg.length + 4 + mediaType.length + dataLength);
+    const msg = new Uint8Array(1 + 4 + 1 + 4 + errorMsg.length + dataLength);
     const view = new DataView(msg.buffer, msg.byteOffset, msg.byteLength);
     let offset = 0;
     view.setUint8(offset, BinaryOpcode.FETCH_ASSET_RESPONSE);
@@ -633,10 +632,6 @@ export default class FoxgloveServer {
     offset += 4;
     msg.set(errorMsg, offset);
     offset += errorMsg.length;
-    view.setUint32(offset, mediaType.length, true);
-    offset += 4;
-    msg.set(mediaType, offset);
-    offset += mediaType.length;
 
     if (isSuccess) {
       msg.set(

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -53,9 +53,11 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
 
       if (status === FetchAssetStatus.ERROR) {
         return { op, requestId, status, errorMsg };
-      } else {
+      } else if (status === FetchAssetStatus.SUCCESS) {
         const data = new DataView(buffer, offset, buffer.byteLength - offset);
         return { op, requestId, status, data };
+      } else {
+        throw new Error(`Unrecognized fetch asset status: ${status as number}`);
       }
     }
   }

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -48,11 +48,11 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
       offset += 1;
       const errorMsgLength = view.getUint32(offset, true);
       offset += 4;
-      const errorMsg = textDecoder.decode(new DataView(buffer, offset, errorMsgLength));
+      const error = textDecoder.decode(new DataView(buffer, offset, errorMsgLength));
       offset += errorMsgLength;
 
       if (status === FetchAssetStatus.ERROR) {
-        return { op, requestId, status, errorMsg };
+        return { op, requestId, status, error };
       } else if (status === FetchAssetStatus.SUCCESS) {
         const data = new DataView(buffer, offset, buffer.byteLength - offset);
         return { op, requestId, status, data };

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -35,6 +35,19 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
       const data = new DataView(buffer, offset, buffer.byteLength - offset);
       return { op, serviceId, callId, encoding, data };
     }
+    case BinaryOpcode.ASSET: {
+      const requestId = view.getUint32(offset, true);
+      offset += 4;
+      const lastModified = view.getBigUint64(offset, true);
+      offset += 8;
+      const mediaTypeLength = view.getUint32(offset, true);
+      offset += 4;
+      const mediaTypeBytes = new DataView(buffer, offset, mediaTypeLength);
+      const mediaType = textDecoder.decode(mediaTypeBytes);
+      offset += mediaTypeLength;
+      const data = new DataView(buffer, offset, buffer.byteLength - offset);
+      return { op, requestId, lastModified, mediaType, data };
+    }
   }
   throw new Error(`Unrecognized server opcode in binary message: ${op.toString(16)}`);
 }

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -1,4 +1,10 @@
-import { BinaryOpcode, ClientBinaryOpcode, ClientMessage, ServerMessage } from "./types";
+import {
+  BinaryOpcode,
+  ClientBinaryOpcode,
+  ClientMessage,
+  FetchAssetStatus,
+  ServerMessage,
+} from "./types";
 
 const textDecoder = new TextDecoder();
 
@@ -38,15 +44,20 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
     case BinaryOpcode.ASSET: {
       const requestId = view.getUint32(offset, true);
       offset += 4;
-      const status = view.getUint8(offset);
+      const status = view.getUint8(offset) as FetchAssetStatus;
       offset += 1;
-      const mediaTypeLength = view.getUint32(offset, true);
+      const mediaTypeOrErrMsgLength = view.getUint32(offset, true);
       offset += 4;
-      const mediaTypeBytes = new DataView(buffer, offset, mediaTypeLength);
-      const mediaType = textDecoder.decode(mediaTypeBytes);
-      offset += mediaTypeLength;
-      const data = new DataView(buffer, offset, buffer.byteLength - offset);
-      return { op, requestId, status, mediaType, data };
+      const mediaTypeOrErrMsgBytes = new DataView(buffer, offset, mediaTypeOrErrMsgLength);
+      const mediaTypeOrErr = textDecoder.decode(mediaTypeOrErrMsgBytes);
+
+      if (status === FetchAssetStatus.ERROR) {
+        return { op, requestId, status, errorMsg: mediaTypeOrErr };
+      } else {
+        offset += mediaTypeOrErrMsgLength;
+        const data = new DataView(buffer, offset, buffer.byteLength - offset);
+        return { op, requestId, status, mediaType: mediaTypeOrErr, data };
+      }
     }
   }
   throw new Error(`Unrecognized server opcode in binary message: ${op.toString(16)}`);

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -38,15 +38,15 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
     case BinaryOpcode.ASSET: {
       const requestId = view.getUint32(offset, true);
       offset += 4;
-      const lastModified = view.getBigUint64(offset, true);
-      offset += 8;
+      const status = view.getUint8(offset);
+      offset += 1;
       const mediaTypeLength = view.getUint32(offset, true);
       offset += 4;
       const mediaTypeBytes = new DataView(buffer, offset, mediaTypeLength);
       const mediaType = textDecoder.decode(mediaTypeBytes);
       offset += mediaTypeLength;
       const data = new DataView(buffer, offset, buffer.byteLength - offset);
-      return { op, requestId, lastModified, mediaType, data };
+      return { op, requestId, status, mediaType, data };
     }
   }
   throw new Error(`Unrecognized server opcode in binary message: ${op.toString(16)}`);

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -50,16 +50,12 @@ export function parseServerMessage(buffer: ArrayBuffer): ServerMessage {
       offset += 4;
       const errorMsg = textDecoder.decode(new DataView(buffer, offset, errorMsgLength));
       offset += errorMsgLength;
-      const mediaTypeLength = view.getUint32(offset, true);
-      offset += 4;
-      const mediaType = textDecoder.decode(new DataView(buffer, offset, mediaTypeLength));
-      offset += mediaTypeLength;
 
       if (status === FetchAssetStatus.ERROR) {
         return { op, requestId, status, errorMsg };
       } else {
         const data = new DataView(buffer, offset, buffer.byteLength - offset);
-        return { op, requestId, status, mediaType, data };
+        return { op, requestId, status, data };
       }
     }
   }

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -22,6 +22,10 @@ export enum ServerCapability {
   connectionGraph = "connectionGraph",
   assets = "assets",
 }
+export enum FetchAssetStatus {
+  SUCCESS = 0,
+  ERROR = 1,
+}
 
 export type ChannelId = number;
 export type ClientChannelId = number;
@@ -196,13 +200,20 @@ export type Time = {
 export type ServiceCallResponse = ServiceCallPayload & {
   op: BinaryOpcode.SERVICE_CALL_RESPONSE;
 };
-export type Asset = {
+export type FetchAssetSuccessResponse = {
   op: BinaryOpcode.ASSET;
   requestId: number;
-  status: number;
+  status: FetchAssetStatus.SUCCESS;
   mediaType: string;
   data: DataView;
 };
+export type FetchAssetErrorResponse = {
+  op: BinaryOpcode.ASSET;
+  requestId: number;
+  status: FetchAssetStatus.ERROR;
+  errorMsg: string;
+};
+export type FetchAssetResponse = FetchAssetSuccessResponse | FetchAssetErrorResponse;
 export type ClientPublish = {
   channel: ClientChannel;
   data: DataView;
@@ -232,7 +243,7 @@ export type ServerMessage =
   | ServiceCallResponse
   | ParameterValues
   | ConnectionGraphUpdate
-  | Asset;
+  | FetchAssetResponse;
 
 /**
  * Abstraction that supports both browser and Node WebSocket clients.

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -163,7 +163,7 @@ export type UnsubscribeConnectionGraph = {
 };
 export type FetchAsset = {
   op: "fetchAsset";
-  uri: string;
+  assetId: string;
   requestId: number;
 };
 export type ConnectionGraphUpdate = {
@@ -199,7 +199,7 @@ export type ServiceCallResponse = ServiceCallPayload & {
 export type Asset = {
   op: BinaryOpcode.ASSET;
   requestId: number;
-  lastModified: bigint;
+  status: number;
   mediaType: string;
   data: DataView;
 };

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -2,7 +2,7 @@ export enum BinaryOpcode {
   MESSAGE_DATA = 1,
   TIME = 2,
   SERVICE_CALL_RESPONSE = 3,
-  ASSET = 4,
+  FETCH_ASSET_RESPONSE = 4,
 }
 export enum ClientBinaryOpcode {
   MESSAGE_DATA = 1,
@@ -201,14 +201,14 @@ export type ServiceCallResponse = ServiceCallPayload & {
   op: BinaryOpcode.SERVICE_CALL_RESPONSE;
 };
 export type FetchAssetSuccessResponse = {
-  op: BinaryOpcode.ASSET;
+  op: BinaryOpcode.FETCH_ASSET_RESPONSE;
   requestId: number;
   status: FetchAssetStatus.SUCCESS;
   mediaType: string;
   data: DataView;
 };
 export type FetchAssetErrorResponse = {
-  op: BinaryOpcode.ASSET;
+  op: BinaryOpcode.FETCH_ASSET_RESPONSE;
   requestId: number;
   status: FetchAssetStatus.ERROR;
   errorMsg: string;

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -167,7 +167,7 @@ export type UnsubscribeConnectionGraph = {
 };
 export type FetchAsset = {
   op: "fetchAsset";
-  assetURI: string;
+  assetUri: string;
   requestId: number;
 };
 export type ConnectionGraphUpdate = {

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -2,6 +2,7 @@ export enum BinaryOpcode {
   MESSAGE_DATA = 1,
   TIME = 2,
   SERVICE_CALL_RESPONSE = 3,
+  ASSET = 4,
 }
 export enum ClientBinaryOpcode {
   MESSAGE_DATA = 1,
@@ -19,6 +20,7 @@ export enum ServerCapability {
   parametersSubscribe = "parametersSubscribe",
   services = "services",
   connectionGraph = "connectionGraph",
+  assets = "assets",
 }
 
 export type ChannelId = number;
@@ -98,7 +100,8 @@ export type ClientMessage =
   | ClientMessageData
   | ServiceCallRequest
   | SubscribeConnectionGraph
-  | UnsubscribeConnectionGraph;
+  | UnsubscribeConnectionGraph
+  | FetchAsset;
 
 export type ServerInfo = {
   op: "serverInfo";
@@ -158,6 +161,11 @@ export type SubscribeConnectionGraph = {
 export type UnsubscribeConnectionGraph = {
   op: "unsubscribeConnectionGraph";
 };
+export type FetchAsset = {
+  op: "fetchAsset";
+  uri: string;
+  requestId: number;
+};
 export type ConnectionGraphUpdate = {
   op: "connectionGraphUpdate";
   publishedTopics: {
@@ -188,6 +196,13 @@ export type Time = {
 export type ServiceCallResponse = ServiceCallPayload & {
   op: BinaryOpcode.SERVICE_CALL_RESPONSE;
 };
+export type Asset = {
+  op: BinaryOpcode.ASSET;
+  requestId: number;
+  lastModified: bigint;
+  mediaType: string;
+  data: DataView;
+};
 export type ClientPublish = {
   channel: ClientChannel;
   data: DataView;
@@ -216,7 +231,8 @@ export type ServerMessage =
   | Time
   | ServiceCallResponse
   | ParameterValues
-  | ConnectionGraphUpdate;
+  | ConnectionGraphUpdate
+  | Asset;
 
 /**
  * Abstraction that supports both browser and Node WebSocket clients.

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -167,7 +167,7 @@ export type UnsubscribeConnectionGraph = {
 };
 export type FetchAsset = {
   op: "fetchAsset";
-  assetUri: string;
+  uri: string;
   requestId: number;
 };
 export type ConnectionGraphUpdate = {

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -167,7 +167,7 @@ export type UnsubscribeConnectionGraph = {
 };
 export type FetchAsset = {
   op: "fetchAsset";
-  assetId: string;
+  assetURI: string;
   requestId: number;
 };
 export type ConnectionGraphUpdate = {

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -210,7 +210,7 @@ export type FetchAssetErrorResponse = {
   op: BinaryOpcode.FETCH_ASSET_RESPONSE;
   requestId: number;
   status: FetchAssetStatus.ERROR;
-  errorMsg: string;
+  error: string;
 };
 export type FetchAssetResponse = FetchAssetSuccessResponse | FetchAssetErrorResponse;
 export type ClientPublish = {

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -204,7 +204,6 @@ export type FetchAssetSuccessResponse = {
   op: BinaryOpcode.FETCH_ASSET_RESPONSE;
   requestId: number;
   status: FetchAssetStatus.SUCCESS;
-  mediaType: string;
   data: DataView;
 };
 export type FetchAssetErrorResponse = {


### PR DESCRIPTION
### Public-Facing Changes

- Extend spec to allow fetching of assets

### Description
Allows clients to request assets (files) from the server.

Example use case: Client requests mesh files which are referenced by a URDF