### PR TITLE
Add optional `schema`  & `schemaEncoding` fields to client advertise operation

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -326,8 +326,10 @@ Informs the client about updates to the connection graph. This is only sent to c
 - `channels`: array of:
   - `id`: number chosen by the client. The client may reuse ids that have previously been unadvertised.
   - `topic`: string
-  - `encoding`: string, one of the encodings [supported by the server](#server-info)
+  - `encoding`: string, one of the message encodings [supported by the server](#server-info)
   - `schemaName`: string
+  - `schema`: string | undefined, optional [schema definition](#advertise).
+  - `schemaEncoding`: string | undefined, optional [schema encoding](#advertise).
 
 #### Example
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-websocket
-version = 0.1.1
+version = 0.1.2
 description = Foxglove WebSocket server
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/python/src/foxglove_websocket/types.py
+++ b/python/src/foxglove_websocket/types.py
@@ -40,6 +40,8 @@ class ClientChannel(TypedDict):
     topic: str
     encoding: str
     schemaName: str
+    schema: Optional[str]
+    schemaEncoding: Optional[str]
 
 
 class Subscribe(TypedDict):

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -164,9 +164,15 @@ export default class FoxgloveClient {
     this.send({ op: "unsubscribe", subscriptionIds: [subscriptionId] });
   }
 
-  advertise(topic: string, encoding: string, schemaName: string): ClientChannelId {
+  advertise(
+    topic: string,
+    encoding: string,
+    schemaName: string,
+    schema?: string,
+    schemaEncoding?: string,
+  ): ClientChannelId {
     const id = ++this.nextAdvertisementId;
-    const channels: ClientChannel[] = [{ id, topic, encoding, schemaName }];
+    const channels: ClientChannel[] = [{ id, topic, encoding, schemaName, schema, schemaEncoding }];
     this.send({ op: "advertise", channels });
     return id;
   }

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -59,6 +59,8 @@ export type ClientChannel = {
   topic: string;
   encoding: string;
   schemaName: string;
+  schema?: string;
+  schemaEncoding?: string;
 };
 export type ClientAdvertise = {
   op: "advertise";


### PR DESCRIPTION
### Public-Facing Changes

Add optional `schema`  & `schemaEncoding` fields to client advertise operation

### Description
See https://github.com/orgs/foxglove/discussions/728
