### PR TITLE
Add dependabot group for eslint packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
       interval: weekly
     labels: [] # disable default labels
 
+    # Define groups of dependencies to be updated together
+    # https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
+    groups:
+      eslint:
+        patterns:
+          - "@typescript-eslint/*"
+
   - package-ecosystem: pip
     directory: "/"
     schedule:


### PR DESCRIPTION
### Public-Facing Changes

None

### Description
Adds a dependabot group to group eslint package updates together in one PR

From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups:

> By default, Dependabot raises a single pull request for each dependency that needs to be updated to a newer version. You can use groups to create sets of dependencies (per package manager), so that Dependabot opens a single pull request to update multiple dependencies at the same time.
