### PR TITLE
Add parameter type `float64` & `float64_array` for floating point values

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -174,7 +174,7 @@ Informs the client about parameters. Only supported if the server declares the `
 - `parameters`: array of:
   - `name`: string, name of the parameter
   - `value`: ParameterValue, where ParameterValue is of type number | boolean | string | ParameterValue[] | { [key: string]: ParameterValue } | undefined.
-  - `type`: "byte_array" | undefined. If the type is `byte_array`, `value` shall be interpreted as base64 encoded string.
+  - `type`: "byte_array" | "float64" | "float64_array" | undefined. If the type is `byte_array`, `value` shall be interpreted as base64 encoded string. If the type is `float64` or `float64_array`, `value` shall be a 64-bit floating-point number or integer, or an array of them, respectively.
 - `id`: string | undefined. Only set when the [getParameters](#get-parameters) or [setParameters](#set-parameters) request's `id` field was set
 
 #### Example
@@ -188,6 +188,7 @@ Informs the client about parameters. Only supported if the server declares the `
     { "name": "/string_param", "value": "foo" },
     { "name": "/node/nested_ints_param", "value": [1, 2, 3] }
     { "name": "/byte_array_param", "value": "QUJDRA==", "type": "byte_array" },
+    { "name": "/float_param_int", "value": 3, "type": "float64" },
   ],
   "id": "request-123"
 }
@@ -403,7 +404,7 @@ Set one or more parameters. Only supported if the server previously declared tha
 - `parameters`: array of:
   - `name`: string
   - `value`: number | boolean | string | number[] | boolean[] | string[] | undefined. If the value is not set (`undefined`), the parameter shall be unset (removed).
-  - `type`: "byte_array" | undefined. If the type is `byte_array`, `value` shall be a base64 encoded string.
+  - `type`: "byte_array" | "float64" | "float64_array" | undefined. If the type is `byte_array`, `value` shall be a base64 encoded string. If the type is `float64` or `float64_array`, `value` value shall be a 64-bit floating-point number or integer, or an array of them, respectively.
 - `id`: string | undefined, arbitrary string used for identifying the corresponding server [response](#parameter-values). If this field is not set, the server may not send a response to the client.
 
 #### Example
@@ -414,7 +415,8 @@ Set one or more parameters. Only supported if the server previously declared tha
   "parameters": [
     { "name": "/int_param", "value": 3 },
     { "name": "/float_param", "value": 4.1 },
-    { "name": "/byte_array_param", "value": "QUJDRA==", "type": "byte_array" }
+    { "name": "/byte_array_param", "value": "QUJDRA==", "type": "byte_array" },
+    { "name": "/float_array_param", "value": [1.1, 2, 3.3], "type": "float64_array" }
   ],
   "id": "request-456"
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -189,6 +189,7 @@ Informs the client about parameters. Only supported if the server declares the `
     { "name": "/node/nested_ints_param", "value": [1, 2, 3] }
     { "name": "/byte_array_param", "value": "QUJDRA==", "type": "byte_array" },
     { "name": "/float_param_int", "value": 3, "type": "float64" },
+    { "name": "/float_array_param", "value": [1.1, 2, 3.3], "type": "float64_array" },
   ],
   "id": "request-123"
 }
@@ -416,7 +417,8 @@ Set one or more parameters. Only supported if the server previously declared tha
     { "name": "/int_param", "value": 3 },
     { "name": "/float_param", "value": 4.1 },
     { "name": "/byte_array_param", "value": "QUJDRA==", "type": "byte_array" },
-    { "name": "/float_array_param", "value": [1.1, 2, 3.3], "type": "float64_array" }
+    { "name": "/float_param_int", "value": 3, "type": "float64" },
+    { "name": "/float_array_param", "value": [1.1, 2, 3.3], "type": "float64_array" },
   ],
   "id": "request-456"
 }

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -231,7 +231,7 @@ export type ParameterValue =
 export type Parameter = {
   name: string;
   value: ParameterValue;
-  type?: "byte_array";
+  type?: "byte_array" | "float64" | "float64_array";
 };
 
 export type ServerMessage =


### PR DESCRIPTION
### Public-Facing Changes
Add parameter type `float64` & `float64_array` for floating point values

### Description
Some languages, such as JavaScript, do not differentiate between integers and floating point numbers. The `float64` and `float64_array` types were added to avoid ambiguity by informing the client (or the server) that the value is a floating point number, or an array of it, respectively.

Example: When sending the following JSON via JS to the server, the server will receive the value `1` and deduce that the parameter is of type Integer.

```json
{
  "op": "setParameters",
  "parameters": [
    { "name": "/float_param", "value": 1.0 }
  ]
}
```

By adding `"type": "float64"`, the client can let the server know that the value should be treated as a 64-bit floating point number.

Related to FG-4486