### PR TITLE
Fix CI check for using current ws-protocol package not working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: yarn
 
+      - run: yarn install --frozen-lockfile
       - name: Ensure examples use current version of ws-protocol package
         run: "! grep '@foxglove/ws-protocol' yarn.lock"
-
-      - run: yarn install --frozen-lockfile
       - run: yarn workspace @foxglove/${{ matrix.package }} lint:ci
       - run: yarn workspace @foxglove/${{ matrix.package }} test
 


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Fixes the `Ensure examples use current version of ws-protocol package` CI check not working (as no `yarn.lock` file existed)