### PR TITLE
Use latest @foxglove/ws-protocol in examples

### DIFF
--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -67,7 +67,7 @@
     "@foxglove/schemas": "^1.5.1",
     "@foxglove/wasm-lz4": "^1.0.2",
     "@foxglove/wasm-zstd": "^1.0.1",
-    "@foxglove/ws-protocol": "0.7.0",
+    "@foxglove/ws-protocol": "0.7.1",
     "@mcap/core": "^1.2.1",
     "boxen": "^7.1.1",
     "commander": "^11.0.0",


### PR DESCRIPTION
### Public-Facing Changes

None

### Description
Use latest @foxglove/ws-protocol in examples, to make dependabot PRs work again
