### PR TITLE
Add pure CMake support

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,15 +1,85 @@
+# General Info
 cmake_minimum_required(VERSION 3.15)
-project(FoxgloveWebSocket CXX)
+execute_process(COMMAND bash -c "cat conanfile.py | grep -oP '(?<=version = \").*(?=\")'"
+    OUTPUT_VARIABLE CMD_OUT
+    RESULT_VARIABLE CMD_RES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
+if(${CMD_RES} GREATER "0")
+    message(FATAL "Version not discovered in conanfile.py")
+else()
+    message("Configuring foxglove_websocket/${CMD_OUT}")
+endif()
+
+project(foxglove_websocket
+    VERSION ${CMD_OUT}
+    LANGUAGES CXX
+)
+
+# Dependencies
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
-add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp)
-target_include_directories(foxglove_websocket PUBLIC include)
-target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
-set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+# Create library
+add_library(${PROJECT_NAME} 
+    src/base64.cpp
+    src/parameter.cpp
+    src/serialization.cpp
+)
 
-install(TARGETS foxglove_websocket)
-INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-         DESTINATION include)
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
+target_link_libraries(${PROJECT_NAME}
+    nlohmann_json::nlohmann_json
+    websocketpp::websocketpp
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+# Install
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(PACKAGE_INCLUDE_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+set(PACKAGE_LIBRARY_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION ${PACKAGE_INCLUDE_DIR}/
+)
+install(FILES ${CMAKE_SOURCE_DIR}/LICENSE 
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/
+)
+install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    LIBRARY DESTINATION ${PACKAGE_LIBRARY_DIR}
+)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    VERSION "${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}"
+    COMPATIBILITY AnyNewerVersion
+)
+install(EXPORT ${PROJECT_NAME}-targets
+    NAMESPACE "${PROJECT_NAME}::"
+    FILE ${PROJECT_NAME}-targets.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
+install(
+    FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,16 +1,19 @@
 # General Info
 cmake_minimum_required(VERSION 3.15)
-set(CMD "cat ${CMAKE_CURRENT_LIST_DIR}/conanfile.py | grep -oP '(?<=version = \").*(?=\")'")
-execute_process(COMMAND bash -c "${CMD}"
-    OUTPUT_VARIABLE CMD_OUT
-    RESULT_VARIABLE CMD_RES
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
 
-if(${CMD_RES} GREATER "0")
-    message(FATAL "Version not discovered in conanfile.py")
-else()
-    message("Configuring foxglove_websocket/${CMD_OUT}")
+if(NOT ${USE_CONAN})
+    set(CMD "cat ${CMAKE_CURRENT_LIST_DIR}/conanfile.py | grep -oP '(?<=version = \").*(?=\")'")
+    execute_process(COMMAND bash -c "${CMD}"
+        OUTPUT_VARIABLE CMD_OUT
+        RESULT_VARIABLE CMD_RES
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(${CMD_RES} GREATER "0")
+        message(FATAL "Version not discovered in conanfile.py")
+    else()
+        message("Configuring foxglove_websocket/${CMD_OUT}")
+    endif()
 endif()
 
 project(foxglove_websocket
@@ -45,42 +48,44 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 # Install
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+if(NOT ${USE_CONAN})
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
 
-set(PACKAGE_INCLUDE_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
-set(PACKAGE_LIBRARY_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
+    set(PACKAGE_INCLUDE_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+    set(PACKAGE_LIBRARY_DIR ${CMAKE_INSTALL_FULL_LIBDIR})
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-    DESTINATION ${PACKAGE_INCLUDE_DIR}/
-)
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE 
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/
-)
-install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}-targets
-    LIBRARY DESTINATION ${PACKAGE_LIBRARY_DIR}
-)
-configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
-    NO_SET_AND_CHECK_MACRO
-    NO_CHECK_REQUIRED_COMPONENTS_MACRO
-)
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-    VERSION "${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}"
-    COMPATIBILITY AnyNewerVersion
-)
-install(EXPORT ${PROJECT_NAME}-targets
-    NAMESPACE "${PROJECT_NAME}::"
-    FILE ${PROJECT_NAME}-targets.cmake
-    DESTINATION lib/cmake/${PROJECT_NAME}
-)
-install(
-    FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-    DESTINATION lib/cmake/${PROJECT_NAME}
-)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+        DESTINATION ${PACKAGE_INCLUDE_DIR}/
+    )
+    install(FILES ${CMAKE_SOURCE_DIR}/LICENSE 
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/
+    )
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
+        LIBRARY DESTINATION ${PACKAGE_LIBRARY_DIR}
+    )
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+        INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+        NO_SET_AND_CHECK_MACRO
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO
+    )
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+        VERSION "${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}"
+        COMPATIBILITY AnyNewerVersion
+    )
+    install(EXPORT ${PROJECT_NAME}-targets
+        NAMESPACE "${PROJECT_NAME}::"
+        FILE ${PROJECT_NAME}-targets.cmake
+        DESTINATION lib/cmake/${PROJECT_NAME}
+    )
+    install(
+        FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+        DESTINATION lib/cmake/${PROJECT_NAME}
+    )
+endif()

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,6 +1,7 @@
 # General Info
 cmake_minimum_required(VERSION 3.15)
-execute_process(COMMAND bash -c "cat conanfile.py | grep -oP '(?<=version = \").*(?=\")'"
+set(CMD "cat ${CMAKE_CURRENT_LIST_DIR}/conanfile.py | grep -oP '(?<=version = \").*(?=\")'")
+execute_process(COMMAND bash -c "${CMD}"
     OUTPUT_VARIABLE CMD_OUT
     RESULT_VARIABLE CMD_RES
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,7 +1,7 @@
 # General Info
 cmake_minimum_required(VERSION 3.15)
 
-if(NOT ${USE_CONAN})
+if(NOT ${CONAN_EXPORTED})
     set(CMD "cat ${CMAKE_CURRENT_LIST_DIR}/conanfile.py | grep -oP '(?<=version = \").*(?=\")'")
     execute_process(COMMAND bash -c "${CMD}"
         OUTPUT_VARIABLE CMD_OUT
@@ -48,7 +48,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 # Install
-if(NOT ${USE_CONAN})
+if(NOT ${CONAN_EXPORTED})
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 

--- a/cpp/foxglove-websocket/cmake/config.cmake.in
+++ b/cpp/foxglove-websocket/cmake/config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake" )

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -38,7 +38,7 @@ class FoxgloveWebSocketConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(variables={"USE_CONAN": "ON"})
+        cmake.configure()
         cmake.build()
 
     def package(self):

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -38,7 +38,7 @@ class FoxgloveWebSocketConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(variables={"USE_CONAN": "ON"})
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
### Public-Facing Changes

- Adds CMake support

### Description

We internally use CMake-based tooling to build packages from source and install. This PR improves the existing `CMakeLists.txt` to install CMake config. 