### PR TITLE
Add server factory, provide definition of setupTlsHandler()

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -4,7 +4,7 @@ project(FoxgloveWebSocket CXX)
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
-add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp)
+add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
 target_include_directories(foxglove_websocket PUBLIC include)
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_factory.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_factory.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <websocketpp/common/connection_hdl.hpp>
+
+#include <memory>
+#include <string>
+
+#include "common.hpp"
+#include "server_interface.hpp"
+
+namespace foxglove {
+
+class ServerFactory {
+public:
+  template <typename ConnectionHandle>
+  static std::unique_ptr<ServerInterface<ConnectionHandle>> createServer(
+    const std::string& name, const std::function<void(WebSocketLogLevel, char const*)>& logHandler,
+    const ServerOptions& options);
+};
+
+}  // namespace foxglove

--- a/cpp/foxglove-websocket/src/server_factory.cpp
+++ b/cpp/foxglove-websocket/src/server_factory.cpp
@@ -1,0 +1,62 @@
+#include <foxglove/websocket/server_factory.hpp>
+#include <foxglove/websocket/websocket_notls.hpp>
+#include <foxglove/websocket/websocket_server.hpp>
+#include <foxglove/websocket/websocket_tls.hpp>
+
+#include <websocketpp/common/connection_hdl.hpp>
+
+namespace foxglove {
+
+template <>
+std::unique_ptr<ServerInterface<websocketpp::connection_hdl>> ServerFactory::createServer(
+  const std::string& name, const std::function<void(WebSocketLogLevel, char const*)>& logHandler,
+  const ServerOptions& options) {
+  if (options.useTls) {
+    return std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(name, logHandler, options);
+  } else {
+    return std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(name, logHandler, options);
+  }
+}
+
+template <>
+inline void Server<WebSocketNoTls>::setupTlsHandler() {
+  _server.get_alog().write(APP, "Server running without TLS");
+}
+
+template <>
+inline void Server<WebSocketTls>::setupTlsHandler() {
+  _server.set_tls_init_handler([this](ConnHandle hdl) {
+    (void)hdl;
+
+    namespace asio = websocketpp::lib::asio;
+    auto ctx = websocketpp::lib::make_shared<asio::ssl::context>(asio::ssl::context::sslv23);
+
+    try {
+      ctx->set_options(asio::ssl::context::default_workarounds | asio::ssl::context::no_tlsv1 |
+                       asio::ssl::context::no_sslv2 | asio::ssl::context::no_sslv3);
+      ctx->use_certificate_chain_file(_options.certfile);
+      ctx->use_private_key_file(_options.keyfile, asio::ssl::context::pem);
+
+      // Ciphers are taken from the websocketpp example echo tls server:
+      // https://github.com/zaphoyd/websocketpp/blob/1b11fd301/examples/echo_server_tls/echo_server_tls.cpp#L119
+      constexpr char ciphers[] =
+        "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+"
+        "AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-"
+        "AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-"
+        "ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-"
+        "AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:"
+        "!MD5:!PSK";
+
+      if (SSL_CTX_set_cipher_list(ctx->native_handle(), ciphers) != 1) {
+        _server.get_elog().write(RECOVERABLE, "Error setting cipher list");
+      }
+    } catch (const std::exception& ex) {
+      _server.get_elog().write(RECOVERABLE,
+                               std::string("Exception in TLS handshake: ") + ex.what());
+    }
+    return ctx;
+  });
+}
+
+}  // namespace foxglove

--- a/cpp/foxglove-websocket/src/server_factory.cpp
+++ b/cpp/foxglove-websocket/src/server_factory.cpp
@@ -19,12 +19,12 @@ std::unique_ptr<ServerInterface<websocketpp::connection_hdl>> ServerFactory::cre
 }
 
 template <>
-inline void Server<WebSocketNoTls>::setupTlsHandler() {
+void Server<WebSocketNoTls>::setupTlsHandler() {
   _server.get_alog().write(APP, "Server running without TLS");
 }
 
 template <>
-inline void Server<WebSocketTls>::setupTlsHandler() {
+void Server<WebSocketTls>::setupTlsHandler() {
   _server.set_tls_init_handler([this](ConnHandle hdl) {
     (void)hdl;
 


### PR DESCRIPTION
### Public-Facing Changes

- Provide definition of `Server<Config>::setupTlsHandler()`

### Description
So far we did not provide the definition of `Server<Config>::setupTlsHandler()`, requiring the user to implement it themselves. This PR adds the `setupTlsHandler()` implementation taken from [foxglove_bridge](https://github.com/foxglove/ros-foxglove-bridge).

Fixes #540 
