### PR TITLE
spec: Allow specifying service schema names & encodings

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -204,20 +204,20 @@ Informs the client about available services. Only supported if the server declar
 - `op`: string `"advertiseServices"`
 - `services`: array of:
   - `id`: number. The server may reuse ids when services disappear and reappear, but only if the services keeps the exact same name, type, and schema. Clients will use this unique id to cache schema info and deserialization routines.
-  - `name`: string
-  - `type`: string
-  - `requestSchema`: string, required if `request` is not given. Field is present for backwards compatibilty, prefer using `request` instead.
-  - `request`: object, required if `requestSchema` is not given.
-    - `encoding`: string
-    - `schemaName`: string
-    - `schemaEncoding`: string
-    - `schema`: string
-  - `responseSchema`: string, required if `response` is not given. Field is present for backwards compatibilty, prefer using `response` instead.
-  - `response`: object, required if `responseSchema` is not given.
-    - `encoding`: string
-    - `schemaName`: string
-    - `schemaEncoding`: string
-    - `schema`: string
+  - `name`: string, name used to identify the service.
+  - `type`: string, type of the service. May be used to derive request & response schema names if `request` or `response` are not given.
+  - `request`: object describing the request. Required if `requestSchema` is not given.
+    - `encoding`: string, type of encoding used for request message encoding.
+    - `schemaName`: string, name of the request schema.
+    - `schemaEncoding`: string, type of encoding used for schema encoding.
+    - `schema`: string, schema definition in a format matching the `schemaEncoding`.
+  - `response`: object describing the response. Required if `responseSchema` is not given.
+    - `encoding`: string, type of encoding used for response message encoding.
+    - `schemaName`: string, name of the response schema.
+    - `schemaEncoding`: string, type of encoding used for schema encoding.
+    - `schema`: string, schema definition in a format matching the `schemaEncoding`.
+  - `requestSchema`: string | undefined, request schema definition. The schema encoding will be derived from the [`supportedEncodings`](#server-info) sent by the server. Required if `request` is not given. Field is present for backwards compatibilty, prefer using `request` instead.
+  - `responseSchema`: string | undefined, response schema definition. The schema encoding will be derived from the [`supportedEncodings`](#server-info) sent by the server. Required if `response` is not given. Field is present for backwards compatibilty, prefer using `response` instead.
 
 
 #### Example

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -206,14 +206,19 @@ Informs the client about available services. Only supported if the server declar
   - `id`: number. The server may reuse ids when services disappear and reappear, but only if the services keeps the exact same name, type, and schema. Clients will use this unique id to cache schema info and deserialization routines.
   - `name`: string
   - `type`: string
-  - `requestSchema`: string (schema data only) or object with the fields below. If given as string, schema name and encoding will be derived from `type` (by appending `_Request`) and the previously advertised [supportedEncodings](#server-info).
-    - `name`: string
+  - `requestSchema`: string, required if `request` is not given. Field is present for backwards compatibilty, prefer using `request` instead.
+  - `request`: object, required if `requestSchema` is not given.
     - `encoding`: string
-    - `data`: string
-  - `responseSchema`: string (schema data only) or object with the fields below. If given as string, schema name and encoding will be derived from `type` (by appending `_Response`) and the previously advertised [supportedEncodings](#server-info).
-    - `name`: string
+    - `schemaName`: string
+    - `schemaEncoding`: string
+    - `schema`: string
+  - `responseSchema`: string, required if `response` is not given. Field is present for backwards compatibilty, prefer using `response` instead.
+  - `response`: object, required if `responseSchema` is not given.
     - `encoding`: string
-    - `data`: string
+    - `schemaName`: string
+    - `schemaEncoding`: string
+    - `schema`: string
+
 
 #### Example
 
@@ -232,8 +237,8 @@ Informs the client about available services. Only supported if the server declar
       "id": 2,
       "name": "set_bool",
       "type": "std_srvs/SetBool",
-      "requestSchema": { "name": "std_srvs/SetBool_Request", "encoding": "ros1msg", "data": "bool data" },
-      "responseSchema": { "name": "std_srvs/SetBool_Response", "encoding": "ros1msg", "data": "bool success\nstring message" }
+      "request": { "encoding": "ros1", "schemaName": "std_srvs/SetBool_Request", "schemaEncoding": "ros1msg", "schema": "bool data" },
+      "response": { "encoding": "ros1", "schemaName": "std_srvs/SetBool_Response", "schemaEncoding": "ros1msg", "schema": "bool success\nstring message" }
     }
   ]
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -206,8 +206,14 @@ Informs the client about available services. Only supported if the server declar
   - `id`: number. The server may reuse ids when services disappear and reappear, but only if the services keeps the exact same name, type, and schema. Clients will use this unique id to cache schema info and deserialization routines.
   - `name`: string
   - `type`: string
-  - `requestSchema`: string
-  - `responseSchema`: string
+  - `requestSchema`: string (schema data only) or object with the fields below. If given as string, schema name and encoding will be derived from `type` (by appending `_Request`) and the previously advertised [supportedEncodings](#server-info).
+    - `name`: string
+    - `encoding`: string
+    - `data`: string
+  - `responseSchema`: string (schema data only) or object with the fields below. If given as string, schema name and encoding will be derived from `type` (by appending `_Response`) and the previously advertised [supportedEncodings](#server-info).
+    - `name`: string
+    - `encoding`: string
+    - `data`: string
 
 #### Example
 
@@ -218,9 +224,16 @@ Informs the client about available services. Only supported if the server declar
     {
       "id": 1,
       "name": "foo",
-      "type": "std_srvs/srv/Empty",
+      "type": "std_srvs/Empty",
       "requestSchema": "",
       "responseSchema": ""
+    },
+    {
+      "id": 2,
+      "name": "set_bool",
+      "type": "std_srvs/SetBool",
+      "requestSchema": { "name": "std_srvs/SetBool_Request", "encoding": "ros1msg", "data": "bool data" },
+      "responseSchema": { "name": "std_srvs/SetBool_Response", "encoding": "ros1msg", "data": "bool success\nstring message" }
     }
   ]
 }


### PR DESCRIPTION
### Public-Facing Changes

spec: Allow specifying service schema names & encodings

### Description
Allows for customization of service schema names and schema encodings.

Partially fixes https://github.com/foxglove/studio/issues/6970 
Partially resolves FG-5280