### PR TITLE
Fix GitHub Pages build

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,8 +1,8 @@
-name: Deploy test client web app to GitHub Pages
+name: GitHub Pages
 
 on:
   push:
-    branches: [$default-branch]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

`$default-branch` is not valid syntax in a workflow.

Also shortened the workflow name so it doesn't get truncated as much.