### PR TITLE
Adapt typescript service examples to new spec

### DIFF
--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -67,7 +67,7 @@
     "@foxglove/schemas": "^1.6.2",
     "@foxglove/wasm-lz4": "^1.0.2",
     "@foxglove/wasm-zstd": "^1.0.1",
-    "@foxglove/ws-protocol": "0.7.1",
+    "@foxglove/ws-protocol": "0.7.2",
     "@mcap/core": "^1.3.0",
     "boxen": "^7.1.1",
     "commander": "^11.0.0",

--- a/typescript/ws-protocol-examples/src/examples/service-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-client.ts
@@ -36,8 +36,9 @@ async function main(url: string) {
 
     const msgEncoding = service.request?.encoding ?? fallbackMsgEncoding;
     if (msgEncoding == undefined) {
+      const supportedEndingsStr = SUPPORTED_MSG_ENCODINGS.join(", ");
       throw new Error(
-        `Unable to call servicd ${service.name}: No supported message encoding found.`,
+        `Unable to call service ${service.name}: No supported message encoding found. Supported encodings: [${supportedEndingsStr}]`,
       );
     }
 

--- a/typescript/ws-protocol-examples/src/examples/service-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-client.ts
@@ -1,15 +1,19 @@
 import { MessageWriter as Ros1MessageWriter } from "@foxglove/rosmsg-serialization";
 import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
 import { FoxgloveClient } from "@foxglove/ws-protocol";
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import Debug from "debug";
 import WebSocket from "ws";
 
 const log = Debug("foxglove:service-client");
 Debug.enable("foxglove:*");
 
-async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
+const SUPPORTED_MSG_ENCODINGS = ["json", "ros1", "cdr"];
+
+async function main(url: string) {
   const address = url.startsWith("ws://") || url.startsWith("wss://") ? url : `ws://${url}`;
+  let fallbackMsgEncoding: string | undefined;
+
   log(`Client connecting to ${address}`);
   const client = new FoxgloveClient({
     ws: new WebSocket(address, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
@@ -20,14 +24,9 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
   });
   client.on("serverInfo", (serverInfo) => {
     const supportedEncodings = serverInfo.supportedEncodings ?? [];
-    if (!supportedEncodings.includes(args.encoding)) {
-      log(
-        "Error",
-        "Chosen encoding is not supported by the server. Server only supports the following encodings: ",
-        supportedEncodings,
-      );
-      client.close();
-    }
+    fallbackMsgEncoding = supportedEncodings.find((encoding) =>
+      SUPPORTED_MSG_ENCODINGS.includes(encoding),
+    );
   });
   client.on("advertiseServices", (services) => {
     const service = services.find((s) => /std_srvs(\/srv)?\/SetBool/.test(s.type));
@@ -35,10 +34,17 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
       return;
     }
 
+    const msgEncoding = service.request?.encoding ?? fallbackMsgEncoding;
+    if (msgEncoding == undefined) {
+      throw new Error(
+        `Unable to call servicd ${service.name}: No supported message encoding found.`,
+      );
+    }
+
     let requestData: Uint8Array = new Uint8Array();
-    if (args.encoding === "json") {
+    if (msgEncoding === "json") {
       requestData = new Uint8Array(Buffer.from(JSON.stringify({ data: true })));
-    } else if (args.encoding === "ros1") {
+    } else if (msgEncoding === "ros1") {
       const writer = new Ros1MessageWriter([{ definitions: [{ name: "data", type: "bool" }] }]);
       requestData = writer.writeMessage({ data: true });
     } else {
@@ -49,7 +55,7 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
     client.sendServiceCallRequest({
       serviceId: service.id,
       callId: 123,
-      encoding: args.encoding,
+      encoding: msgEncoding,
       data: new DataView(requestData.buffer),
     });
   });
@@ -70,10 +76,5 @@ async function main(url: string, args: { encoding: "json" | "ros1" | "cdr" }) {
 
 export default new Command("service-client")
   .description("connect to a server and call the first advertised SetBool service")
-  .addOption(
-    new Option("-e, --encoding <encoding>", "message encoding")
-      .choices(["json", "ros1", "cdr"])
-      .default("json"),
-  )
   .argument("[url]", "ws(s)://host:port", "ws://localhost:8765")
   .action(main);

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -52,26 +52,26 @@ async function main(): Promise<void> {
       encoding: "json",
       schemaName: "SetBoolJsonRequest",
       schemaEncoding: "jsonschema",
-      schema: `{
-        "$schema": "https://json-schema.org/draft/2019-09/schema",
-          "type": "object",
-          "properties": {
-             "data": { "type": "boolean"}
-          }
-      }`,
+      schema: JSON.stringify({
+        $schema: "https://json-schema.org/draft/2019-09/schema",
+        type: "object",
+        properties: {
+          data: { type: "boolean" },
+        },
+      }),
     },
     response: {
       encoding: "json",
       schemaName: "SetBoolJsonResponse",
       schemaEncoding: "jsonschema",
-      schema: `{
-        "$schema": "https://json-schema.org/draft/2019-09/schema",
-          "type": "object",
-          "properties": {
-             "success": { "type": "boolean"},
-             "message": { "type": "string"}
-          }
-      }`,
+      schema: JSON.stringify({
+        $schema: "https://json-schema.org/draft/2019-09/schema",
+        type: "object",
+        properties: {
+          success: { type: "boolean" },
+          message: { type: "string" },
+        },
+      }),
     },
   };
 

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -1,6 +1,10 @@
 import { MessageWriter as Ros1MessageWriter } from "@foxglove/rosmsg-serialization";
-import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
-import { FoxgloveServer, ServerCapability, ServiceCallPayload } from "@foxglove/ws-protocol";
+import {
+  FoxgloveServer,
+  ServerCapability,
+  Service,
+  ServiceCallPayload,
+} from "@foxglove/ws-protocol";
 import { Command } from "commander";
 import Debug from "debug";
 import { WebSocketServer } from "ws";
@@ -12,7 +16,7 @@ const log = Debug("foxglove:service-server");
 Debug.enable("foxglove:*");
 
 async function main(): Promise<void> {
-  const supportedEncodings = ["json", "ros1", "cdr"];
+  const supportedEncodings = ["json", "ros1"];
   const server = new FoxgloveServer({
     name: "service-server",
     capabilities: [ServerCapability.services],
@@ -25,13 +29,56 @@ async function main(): Promise<void> {
   });
   setupSigintHandler(log, ws);
 
-  const service = {
-    name: "/set_bool",
-    requestSchema: "bool data",
-    responseSchema: "bool success\nstring message",
+  const serviceDefRos: Omit<Service, "id"> = {
+    name: "/set_bool_ros",
     type: "std_srvs/SetBool",
+    request: {
+      encoding: "ros1",
+      schemaName: "std_srvs/SetBool_Request",
+      schemaEncoding: "ros1msg",
+      schema: "bool data",
+    },
+    response: {
+      encoding: "ros1",
+      schemaName: "std_srvs/SetBool_Response",
+      schemaEncoding: "ros1msg",
+      schema: "bool success\nstring message",
+    },
   };
-  const serviceId = server.addService(service);
+  const serviceDefJson: Omit<Service, "id"> = {
+    name: "/set_bool_json",
+    type: "std_srvs/SetBool",
+    request: {
+      encoding: "json",
+      schemaName: "SetBoolJsonRequest",
+      schemaEncoding: "jsonschema",
+      schema: `{
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+             "data": { "type": "boolean"}
+          }
+      }`,
+    },
+    response: {
+      encoding: "json",
+      schemaName: "SetBoolJsonResponse",
+      schemaEncoding: "jsonschema",
+      schema: `{
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": {
+             "success": { "type": "boolean"},
+             "message": { "type": "string"}
+          }
+      }`,
+    },
+  };
+
+  const serviceById = new Map([
+    [server.addService(serviceDefRos), serviceDefRos],
+    [server.addService(serviceDefJson), serviceDefJson],
+  ]);
 
   ws.on("listening", () => {
     void boxen(
@@ -46,35 +93,35 @@ async function main(): Promise<void> {
     server.handleConnection(conn, name);
   });
   server.on("serviceCallRequest", (request, clientConnection) => {
-    if (request.serviceId !== serviceId) {
+    const service = serviceById.get(request.serviceId);
+    if (!service) {
       throw new Error(`Received invalid serviceId: "${request.serviceId}"`);
     }
-    if (!supportedEncodings.includes(request.encoding)) {
-      throw new Error(`Received invalid encoding: "${request.encoding}"`);
+    if (service.request!.encoding !== request.encoding) {
+      throw new Error(
+        `Service ${service.name} called with invalid message encoding. Expected ${
+          service.request!.encoding
+        }, got ${request.encoding}`,
+      );
     }
 
     log("Received service call request with %d bytes", request.data.byteLength);
 
     const responseMsg = {
       success: true,
-      message: `Hello back`,
+      message: `Service ${service.name} successfully called`,
     };
-
     let responseData = new Uint8Array();
     if (request.encoding === "json") {
       responseData = new Uint8Array(Buffer.from(JSON.stringify(responseMsg)));
-    } else if (request.encoding === "ros1" || request.encoding === "cdr") {
+    } else {
       const definitions = [
         { name: "success", type: "bool" },
         { name: "message", type: "string" },
       ];
-      const writer =
-        request.encoding === "ros1"
-          ? new Ros1MessageWriter([{ definitions }])
-          : new Ros2MessageWriter([{ definitions }]);
+      const writer = new Ros1MessageWriter([{ definitions }]);
       responseData = writer.writeMessage(responseMsg);
     }
-
     const response: ServiceCallPayload = {
       ...request,
       data: new DataView(responseData.buffer),
@@ -87,5 +134,5 @@ async function main(): Promise<void> {
 }
 
 export default new Command("service-server")
-  .description("advertises a SetBool service that can be called")
+  .description("advertises a ROS1 and JSON SetBool service that can be called")
   .action(main);


### PR DESCRIPTION
### Public-Facing Changes

Adapt typescript service examples to new spec

### Description
Uses the latest `advertiseService` spec update. Got slightly more complex but mainly due to an additional service endpoint being added.