### PR TITLE
Add schemaEncoding to mcap-play channel registration

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -132,6 +132,7 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
               topic: record.topic,
               schemaName: schema.name,
               encoding: record.messageEncoding,
+              schemaEncoding: schema.encoding,
               schema:
                 schema.encoding === "protobuf"
                   ? Buffer.from(schema.data).toString("base64")


### PR DESCRIPTION
This conveys the schema encoding to the client allowing it to use the correct parser to handle the schema.