### PR TITLE
Add support for details in messages from the server

### DIFF
--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -140,7 +140,8 @@ export type ServerInfo = {
 export type StatusMessage = {
   op: "status";
   level: StatusLevel;
-  message?: string;
+  message: string;
+  tip?: string;
 };
 export type Advertise = {
   op: "advertise";

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -140,7 +140,7 @@ export type ServerInfo = {
 export type StatusMessage = {
   op: "status";
   level: StatusLevel;
-  message: string;
+  message?: string;
 };
 export type Advertise = {
   op: "advertise";


### PR DESCRIPTION
### Public-Facing Changes

Adds an optional field to status messages from the server

### Description

Websocket servers can send status messages to the client where they will show up as problems, but they will always have a subtext of 'no details provided' because there is no way to supply details or 'tips' to the client despite the client having facilities to support it (in Problem) 

It would be nice to add a (maybe non-spec) optional field to the status message that will allow the client the possibility to display tips if the client supports tips, and otherwise be ignored
