### PR TITLE
mcap-play: Play at wall speed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -158,13 +158,13 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
             }
 
             // Time from the first message to this message
-            const elapsedMessageTime = Number(record.logTime - firstMessageTime) / 1_000_000;
+            const elapsedMessageTimeMs = Number(record.logTime - firstMessageTime) / 1_000_000;
             // Wall time from start until now
-            const elapsedWallTime = performance.now() - startTime;
-            const timeToWait = (elapsedMessageTime - elapsedWallTime) / options.rate;
+            const elapsedWallTimeMs = performance.now() - startTime;
+            const timeToWaitMs = (elapsedMessageTimeMs - elapsedWallTimeMs) / options.rate;
 
-            if (timeToWait > 0) {
-              await delay(timeToWait);
+            if (timeToWaitMs > 0) {
+              await delay(timeToWaitMs);
             }
 
             if (subscribedChannels.has(wsChannelId)) {


### PR DESCRIPTION
### Public-Facing Changes
`mcap-play` now attempts to play messages using `log_time` against the wall clock. Previously it was playing messages as fast as possible regardless of the `log_time` between messages.