### PR TITLE
Fix unnecessary template literal linting error

### DIFF
--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -123,7 +123,7 @@ export default class FoxgloveServer {
     this.capabilities = capabilities ?? [];
     this.supportedEncodings = supportedEncodings;
     this.metadata = metadata;
-    this.sessionId = sessionId ?? `${new Date().toUTCString()}`;
+    this.sessionId = sessionId ?? new Date().toUTCString();
   }
 
   on<E extends EventEmitter.EventNames<EventTypes>>(


### PR DESCRIPTION
### Public-Facing Changes

None

### Description
Caught by a eslint upgrade in https://github.com/foxglove/ws-protocol/pull/652:

```
/home/runner/work/ws-protocol/ws-protocol/typescript/ws-protocol/src/FoxgloveServer.ts
Template literal expression is unnecessary and can be simplified  @typescript-eslint/no-useless-template-literals
```
