### PR TITLE
Bump ws-protocol-examples to 0.7.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol-examples",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Foxglove WebSocket protocol examples",
   "keywords": [
     "foxglove",


### PR DESCRIPTION
### Public-Facing Changes

Fixed: `mcap-play` now plays at the correct speed instead of sending messages as fast as possible (#631)
