### PR TITLE
enable C++ compiler warnings

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -9,6 +9,12 @@ target_include_directories(foxglove_websocket PUBLIC include)
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
+if (MSVC)
+  target_compile_options(foxglove_websocket PRIVATE /WX /W4)
+else()
+  target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Werror -Wold-style-cast -Wfloat-equal)
+endif()
+
 install(TARGETS foxglove_websocket)
 INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
          DESTINATION include)

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -121,7 +121,7 @@ public:
   using Tcp = websocketpp::lib::asio::ip::tcp;
 
   explicit Server(std::string name, LogCallback logger, const ServerOptions& options);
-  virtual ~Server();
+  virtual ~Server() override;
 
   Server(const Server&) = delete;
   Server(Server&&) = delete;
@@ -970,7 +970,7 @@ inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, Ch
     const auto logFn = [this, clientHandle]() {
       sendStatusAndLogMsg(clientHandle, StatusLevel::Warning, "Send buffer limit reached");
     };
-    FOXGLOVE_DEBOUNCE(logFn, 2500);
+    FOXGLOVE_DEBOUNCE(logFn, 2500)
     return;
   }
 


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
- Enables compiler warnings
- Fixes warnings identified by @jhurliman (requires `-Winconsistent-missing-destructor-override` and `-Wextra-semi-stmt`)

