### PR TITLE
Make Server::sendStatusAndLogMsg() public

### DIFF
--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -145,6 +145,8 @@ public:
                         size_t payloadSize) override;
   void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
                    const uint8_t* payload, size_t payloadSize) override;
+  void sendStatusAndLogMsg(ConnHandle clientHandle, const StatusLevel level,
+                           const std::string& message);
   void broadcastTime(uint64_t timestamp) override;
   void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) override;
   void updateConnectionGraph(const MapOfSets& publishedTopics, const MapOfSets& subscribedTopics,
@@ -220,8 +222,6 @@ private:
   void sendJson(ConnHandle hdl, json&& payload);
   void sendJsonRaw(ConnHandle hdl, const std::string& payload);
   void sendBinary(ConnHandle hdl, const uint8_t* payload, size_t payloadSize);
-  void sendStatusAndLogMsg(ConnHandle clientHandle, const StatusLevel level,
-                           const std::string& message);
   void unsubscribeParamsWithoutSubscriptions(ConnHandle hdl,
                                              const std::unordered_set<std::string>& paramNames);
   bool isParameterSubscribed(const std::string& paramName) const;


### PR DESCRIPTION
### Public-Facing Changes

`Server::sendStatusAndLogMsg()` is now a public method, for sending status messages and errors/warnings to clients.

### Description

This method is useful for sending error messages to clients when an action fails, such as requesting an asset that doesn't exist.