### PR TITLE
Improve cpp CMakeLists.txt

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -4,7 +4,7 @@ project(FoxgloveWebSocket CXX)
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
-add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
+add_library(foxglove_websocket STATIC src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
 target_include_directories(foxglove_websocket PUBLIC include)
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
@@ -14,8 +14,3 @@ if (MSVC)
 else()
   target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Werror -Wold-style-cast -Wfloat-equal)
 endif()
-
-install(TARGETS foxglove_websocket)
-INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-         DESTINATION include)
-install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)


### PR DESCRIPTION
### Public-Facing Changes

Removes pointless INSTALL step inside CMakeLists.txt, sets the library to be explicitly static.

### Description

Default for libraries in CMake is `STATIC`. Installation of static libraries is pretty pointless - if it's desired to key off of `BUILD_SHARED_LIBS` or similar, I recommend only installing if built as shared, use `CMAKE_LIST_DIR` to properly support `add_subdirectory`, and to rename `LICENSE` on install to `FOXGLOVE_LICENSE` or similar. This came up trying to use CPM to install (`FetchContent` would have similar issues)