### PR TITLE
Update studio links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Foxglove WebSocket Protocol
 
-This repository provides a [protocol specification](docs/spec.md) and reference implementations enabling [Foxglove Studio](https://github.com/foxglove/studio) to ingest arbitrary “live” streamed data.
+This repository provides a [protocol specification](docs/spec.md) and reference implementations enabling [Foxglove](https://foxglove.dev/) to ingest arbitrary “live” streamed data.
 
-A Foxglove WebSocket server can provide multiple data streams, called _channels_. When a client subscribes to a channel, it begins receiving _messages_ on that channel. This protocol does not prescribe the messages' data format. Instead, the server specifies each channel's _encoding_, and the client uses this information to determine whether it can decode that channel's messages. Read the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#live-connection) for more information on which encodings Studio supports.
+A Foxglove WebSocket server can provide multiple data streams, called _channels_. When a client subscribes to a channel, it begins receiving _messages_ on that channel. This protocol does not prescribe the messages' data format. Instead, the server specifies each channel's _encoding_, and the client uses this information to determine whether it can decode that channel's messages. Read the [Foxglove documentation](https://docs.foxglove.dev/docs/connecting-to-data/frameworks/custom/#live-connection) for more information on which encodings Foxglove supports.
 
 Implementations are available in the following languages:
 
@@ -15,5 +15,5 @@ Implementations are available in the following languages:
 
 ### Additional resources
 - https://foxglove.github.io/ws-protocol - Connect to a ws-protocol compliant server and measure data throughput
-- [eCAL Foxglove Bridge](https://github.com/eclipse-ecal/ecal-foxglove-bridge) – WebSocket bridge that allows users to connect eCAL systems to Foxglove Studio for easy visualization and debugging
+- [eCAL Foxglove Bridge](https://github.com/eclipse-ecal/ecal-foxglove-bridge) – WebSocket bridge that allows users to connect eCAL systems to Foxglove for easy visualization and debugging
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,10 +1,10 @@
-# Foxglove Studio WebSocket protocol v1
+# Foxglove WebSocket protocol v1
 
 ## Protocol overview
 
-- An application wishing to provide data for streamed consumption by Foxglove Studio hosts a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) server.
+- An application wishing to provide data for streamed consumption by Foxglove hosts a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) server.
 
-- The client (Foxglove Studio) will specify supported subprotocols (a standard part of the WebSocket handshake) when establishing the connection. The current version of this document corresponds to subprotocol `foxglove.websocket.v1`. The server must select a subprotocol with which it is compatible for the connection to continue.
+- The client (Foxglove) will specify supported subprotocols (a standard part of the WebSocket handshake) when establishing the connection. The current version of this document corresponds to subprotocol `foxglove.websocket.v1`. The server must select a subprotocol with which it is compatible for the connection to continue.
 
   - Example client code in JavaScript:
     ```js
@@ -123,10 +123,10 @@ Each JSON message must be an object containing a field called `op` which identif
   - `id`: number. The server may reuse ids when channels disappear and reappear, but only if the channel keeps the exact same topic, encoding, schemaName, and schema. Clients will use this unique id to cache schema info and deserialization routines.
   - `topic`: string
   - `encoding`: string, type of encoding used for message encoding
-    > Note: Encodings currently supported by Foxglove Studio are `json`, `protobuf`, `ros1`, and `cdr` (ROS 2). For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
+    > Note: Encodings currently supported by Foxglove are `json`, `protobuf`, `ros1`, and `cdr` (ROS 2). For more information, see the [Foxglove documentation](https://docs.foxglove.dev/docs/connecting-to-data/frameworks/custom/#foxglove-websocket).
   - `schemaName`: string
   - `schema`: string
-    > Note: Foxglove Studio expects the schema to be in a format matching the `schemaEncoding` or alternatively the `encoding` if `schemaEncoding` is not specified. For more information, see the [Foxglove Studio documentation](https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket).
+    > Note: Foxglove expects the schema to be in a format matching the `schemaEncoding` or alternatively the `encoding` if `schemaEncoding` is not specified. For more information, see the [Foxglove documentation](https://docs.foxglove.dev/docs/connecting-to-data/frameworks/custom/#foxglove-websocket).
   - `schemaEncoding`: string | undefined, type of encoding used for schema encoding. May be used if the schema encoding can't be uniquely deduced from the message encoding.
 
 #### Example

--- a/python/README.md
+++ b/python/README.md
@@ -32,7 +32,7 @@ Run a simple example server that publishes messages on a single `example_msg` to
 
 _Note:_ You must exit each server (<kbd>control</kbd> + <kbd>c</kbd>) before starting up another.
 
-To see data from any server, open [Foxglove Studio](https://studio.foxglove.dev?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
+To see data from any server, open [Foxglove Studio](https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
 
 <img width="676" alt="Foxglove Studio displaying data from the example server" src="https://user-images.githubusercontent.com/14237/145260376-ddda98c5-7ed0-4239-9ce4-10778ee8240b.png">
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Foxglove WebSocket server
 
-This package provides a server implementation of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol) with examples. The protocol enables [Foxglove Studio](https://github.com/foxglove/studio) to ingest arbitrary “live” streamed data.
+This package provides a server implementation of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol) with examples. The protocol enables [Foxglove](https://foxglove.dev/) to ingest arbitrary “live” streamed data.
 
 ## Installation
 
@@ -32,9 +32,9 @@ Run a simple example server that publishes messages on a single `example_msg` to
 
 _Note:_ You must exit each server (<kbd>control</kbd> + <kbd>c</kbd>) before starting up another.
 
-To see data from any server, open [Foxglove Studio](https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
+To see data from any server, open [Foxglove](https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
 
-<img width="676" alt="Foxglove Studio displaying data from the example server" src="https://user-images.githubusercontent.com/14237/145260376-ddda98c5-7ed0-4239-9ce4-10778ee8240b.png">
+<img width="676" alt="Foxglove displaying data from the example server" src="https://user-images.githubusercontent.com/14237/145260376-ddda98c5-7ed0-4239-9ce4-10778ee8240b.png">
 
 To customize each server for your specifications, copy either server into a separate file like `server.py` and make the desired adjustments to this template. Start up your server from the command line, using `python3 server.py`.
 
@@ -46,7 +46,7 @@ The [`threaded_server` example](https://github.com/foxglove/ws-protocol/blob/mai
 python -m foxglove_websocket.examples.threaded_server
 ```
 
-When connected to the server in Foxglove Studio, use the [Data Source Info](https://foxglove.dev/docs/studio/panels/data-source-info) panel to see channels appearing and disappearing, and a [Plot](https://foxglove.dev/docs/studio/panels/plot) panel to visualize data on each channel.
+When connected to the server in Foxglove, use the [Data Source Info](https://docs.foxglove.dev/docs/visualization/panels/data-source-info/) panel to see channels appearing and disappearing, and a [Plot](https://docs.foxglove.dev/docs/visualization/panels/plot/) panel to visualize data on each channel.
 
 <img width="869" alt="image" src="https://user-images.githubusercontent.com/14237/154611361-37f87c06-b85f-4117-8bfe-e1bbbc31f7f4.png">
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -9,7 +9,7 @@ license = MIT
 url = https://github.com/foxglove/ws-protocol
 project_urls =
     GitHub Issues = https://github.com/foxglove/ws-protocol/issues
-    Foxglove Studio Documentation = https://foxglove.dev/docs
+    Foxglove Documentation = https://docs.foxglove.dev/
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License

--- a/typescript/ws-protocol-examples/README.md
+++ b/typescript/ws-protocol-examples/README.md
@@ -1,6 +1,6 @@
 # Foxglove WebSocket examples
 
-This package provides example server and client implementations of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol). The protocol enables [Foxglove Studio](https://github.com/foxglove/studio) to ingest arbitrary “live” streamed data.
+This package provides example server and client implementations of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol). The protocol enables [Foxglove](https://foxglove.dev/) to ingest arbitrary “live” streamed data.
 
 To list all possible actions, run the following command:
 
@@ -30,10 +30,10 @@ $ npx @foxglove/ws-protocol-examples@latest mcap-play <file> [--rate 1.0] [--loo
 
 _Note:_ You must exit each server (<kbd>control</kbd> + <kbd>c</kbd>) before starting up another.
 
-To see data from any server, open [Foxglove Studio](https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
+To see data from any server, open [Foxglove](https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
 
-<img width="500" alt="Foxglove Studio displaying memory and CPU usage from the system monitor example" src="https://user-images.githubusercontent.com/14237/145313065-85c05645-6b29-4eb2-a498-849c83f8792d.png">
-<img width="500" alt="Foxglove Studio displaying images from the image server example" src="https://user-images.githubusercontent.com/14237/146500927-4a1408c7-0725-49e7-8185-71b0280c0a8b.png">
+<img width="500" alt="Foxglove displaying memory and CPU usage from the system monitor example" src="https://user-images.githubusercontent.com/14237/145313065-85c05645-6b29-4eb2-a498-849c83f8792d.png">
+<img width="500" alt="Foxglove displaying images from the image server example" src="https://user-images.githubusercontent.com/14237/146500927-4a1408c7-0725-49e7-8185-71b0280c0a8b.png">
 
 ## Example clients
 

--- a/typescript/ws-protocol-examples/README.md
+++ b/typescript/ws-protocol-examples/README.md
@@ -30,7 +30,7 @@ $ npx @foxglove/ws-protocol-examples@latest mcap-play <file> [--rate 1.0] [--loo
 
 _Note:_ You must exit each server (<kbd>control</kbd> + <kbd>c</kbd>) before starting up another.
 
-To see data from any server, open [Foxglove Studio](https://studio.foxglove.dev?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
+To see data from any server, open [Foxglove Studio](https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:8765/) with a Foxglove WebSocket connection to `ws://localhost:8765/`:
 
 <img width="500" alt="Foxglove Studio displaying memory and CPU usage from the system monitor example" src="https://user-images.githubusercontent.com/14237/145313065-85c05645-6b29-4eb2-a498-849c83f8792d.png">
 <img width="500" alt="Foxglove Studio displaying images from the image server example" src="https://user-images.githubusercontent.com/14237/146500927-4a1408c7-0725-49e7-8185-71b0280c0a8b.png">

--- a/typescript/ws-protocol-examples/src/examples/image-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/image-server.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
   ws.on("listening", () => {
     void boxen(
       `📡 Server listening on localhost:${port}. To see data, visit:\n` +
-        `https://studio.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
+        `https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
       { borderStyle: "round", padding: 1 },
     ).then(log);
   });

--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -188,7 +188,7 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
   ws.on("listening", () => {
     void boxen(
       `📡 Server listening on localhost:${port}. To see data, visit:\n` +
-        `https://studio.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
+        `https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
       { borderStyle: "round", padding: 1 },
     )
       .then(log)

--- a/typescript/ws-protocol-examples/src/examples/param-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/param-server.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
   ws.on("listening", () => {
     void boxen(
       `📡 Server listening on localhost:${port}. To see data, visit:\n` +
-        `https://studio.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
+        `https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
       { borderStyle: "round", padding: 1 },
     ).then(log);
   });

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -83,7 +83,7 @@ async function main(): Promise<void> {
   ws.on("listening", () => {
     void boxen(
       `📡 Server listening on localhost:${port}. To see data, visit:\n` +
-        `https://studio.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
+        `https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
       { borderStyle: "round", padding: 1 },
     ).then(log);
   });

--- a/typescript/ws-protocol-examples/src/examples/sysmon.ts
+++ b/typescript/ws-protocol-examples/src/examples/sysmon.ts
@@ -83,7 +83,7 @@ async function main() {
   ws.on("listening", () => {
     void boxen(
       `📡 Server listening on localhost:${port}. To see data, visit:\n` +
-        `https://studio.foxglove.dev/?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
+        `https://app.foxglove.dev/~/view?ds=foxglove-websocket&ds.url=ws://localhost:${port}/`,
       { borderStyle: "round", padding: 1 },
     ).then(log);
   });

--- a/typescript/ws-protocol/README.md
+++ b/typescript/ws-protocol/README.md
@@ -1,6 +1,6 @@
 # Foxglove WebSocket server and client
 
-This package provides a server implementation of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol). This protocol enables [Foxglove Studio](https://github.com/foxglove/studio) to ingest arbitrary “live” streamed data.
+This package provides a server implementation of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol). This protocol enables [Foxglove](https://foxglove.dev/) to ingest arbitrary “live” streamed data.
 
 ## Installation
 

--- a/typescript/ws-protocol/package.json
+++ b/typescript/ws-protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foxglove/ws-protocol",
   "version": "0.7.2",
-  "description": "Foxglove Studio WebSocket protocol",
+  "description": "Foxglove WebSocket protocol",
   "keywords": [
     "foxglove",
     "websocket",


### PR DESCRIPTION
- Update links from `studio.foxglove.dev` to `app.foxglove.dev`
- Update docs links from `foxglove.dev/docs` to `docs.foxglove.dev`
- Update references from "Studio" to "Foxglove"