### PR TITLE
Change log message in cpp example server subscribe handlers

### DIFF
--- a/cpp/examples/src/example_server_flatbuffers.cpp
+++ b/cpp/examples/src/example_server_flatbuffers.cpp
@@ -64,11 +64,13 @@ int main(int argc, char** argv) {
     "C++ FlatBuffers example server", logHandler, serverOptions);
 
   foxglove::ServerHandlers<foxglove::ConnHandle> hdlrs;
-  hdlrs.subscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle) {
-    std::cout << "first client subscribed to " << chanId << std::endl;
+  hdlrs.subscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle clientHandle) {
+    const auto clientStr = server->remoteEndpointString(clientHandle);
+    std::cout << "Client " << clientStr << " subscribed to " << chanId << std::endl;
   };
-  hdlrs.unsubscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle) {
-    std::cout << "last client unsubscribed from " << chanId << std::endl;
+  hdlrs.unsubscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle clientHandle) {
+    const auto clientStr = server->remoteEndpointString(clientHandle);
+    std::cout << "Client " << clientStr << " unsubscribed from " << chanId << std::endl;
   };
   server->setHandlers(std::move(hdlrs));
   server->start("0.0.0.0", 8765);

--- a/cpp/examples/src/example_server_protobuf.cpp
+++ b/cpp/examples/src/example_server_protobuf.cpp
@@ -66,11 +66,13 @@ int main() {
     "C++ Protobuf example server", logHandler, serverOptions);
 
   foxglove::ServerHandlers<foxglove::ConnHandle> hdlrs;
-  hdlrs.subscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle) {
-    std::cout << "first client subscribed to " << chanId << std::endl;
+  hdlrs.subscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle clientHandle) {
+    const auto clientStr = server->remoteEndpointString(clientHandle);
+    std::cout << "Client " << clientStr << " subscribed to " << chanId << std::endl;
   };
-  hdlrs.unsubscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle) {
-    std::cout << "last client unsubscribed from " << chanId << std::endl;
+  hdlrs.unsubscribeHandler = [&](foxglove::ChannelId chanId, foxglove::ConnHandle clientHandle) {
+    const auto clientStr = server->remoteEndpointString(clientHandle);
+    std::cout << "Client " << clientStr << " unsubscribed from " << chanId << std::endl;
   };
   server->setHandlers(std::move(hdlrs));
   server->start("0.0.0.0", 8765);


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Changes the log message in the cpp example server's subscribe/unsubscribe handlers to take into account the client id.

Fixes #688 