### PR TITLE
Add provenance attestation when publishing to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
+        # prevent trying to publish the same package twice with different node versions
         if: ${{ matrix.node-version == '18.x' && startsWith(github.ref, format('refs/tags/releases/typescript/{0}/v', matrix.package)) }}
         # `yarn publish` does not support --provenance
         run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,17 @@ jobs:
       - run: yarn workspace @foxglove/${{ matrix.package }} lint:ci
       - run: yarn workspace @foxglove/${{ matrix.package }} test
 
-      - run: yarn workspace @foxglove/${{ matrix.package }} pack
+      - if: ${{ matrix.package != 'test-client-web-app' }}
+        run: yarn workspace @foxglove/${{ matrix.package }} pack
       - name: Publish to NPM (dry run)
-        if: ${{ matrix.node-version == '18.x' }}
+        if: ${{ matrix.node-version == '18.x' && matrix.package != 'test-client-web-app' }}
         # `yarn publish` does not support --provenance
         run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
         # prevent trying to publish the same package twice with different node versions
-        if: ${{ matrix.node-version == '18.x' && startsWith(github.ref, format('refs/tags/releases/typescript/{0}/v', matrix.package)) }}
+        if: ${{ matrix.node-version == '18.x' && matrix.package != 'test-client-web-app' && startsWith(github.ref, format('refs/tags/releases/typescript/{0}/v', matrix.package)) }}
         # `yarn publish` does not support --provenance
         run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   typescript:
     runs-on: ubuntu-latest
+
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -30,9 +35,15 @@ jobs:
       - run: yarn workspace @foxglove/${{ matrix.package }} lint:ci
       - run: yarn workspace @foxglove/${{ matrix.package }} test
 
+      - run: yarn workspace @foxglove/${{ matrix.package }} pack
+      - name: Publish to NPM (dry run)
+        if: ${{ matrix.node-version == '18.x' }}
+        run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
-        if: ${{ startsWith(github.ref, format('refs/tags/releases/typescript/{0}/v', matrix.package)) }}
-        run: yarn workspace @foxglove/${{ matrix.package }} publish --access public
+        if: ${{ matrix.node-version == '18.x' && startsWith(github.ref, format('refs/tags/releases/typescript/{0}/v', matrix.package)) }}
+        run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,13 @@ jobs:
       - run: yarn workspace @foxglove/${{ matrix.package }} pack
       - name: Publish to NPM (dry run)
         if: ${{ matrix.node-version == '18.x' }}
+        # `yarn publish` does not support --provenance
         run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
         if: ${{ matrix.node-version == '18.x' && startsWith(github.ref, format('refs/tags/releases/typescript/{0}/v', matrix.package)) }}
+        # `yarn publish` does not support --provenance
         run: npm publish typescript/${{ matrix.package }}/*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 node_modules
 *.hdf5
 yarn-error.log
+*.tgz
 
 # Python
 __pycache__


### PR DESCRIPTION
### Changelog
None

### Description

This adds a provenance attestation to the published package so consumers can verify that the package was built on GitHub Actions:
- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

The package will appear like this on npm:

<img src="https://github.blog/wp-content/uploads/2023/04/npm-package-provenance-3.png?w=488&resize=488%2C394" width="250">

Also fixes an [error when publishing](https://github.com/foxglove/ws-protocol/actions/runs/8197963504/job/22420730354) due to trying to publish the same package twice (with different node versions).