### PR TITLE
Fix onerror handler

### DIFF
--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -73,8 +73,8 @@ export default class FoxgloveClient {
 
   #reconnect() {
     this.#ws.binaryType = "arraybuffer";
-    this.#ws.onerror = (event) => {
-      this.#emitter.emit("error", (event as unknown as { error: Error }).error);
+    this.#ws.onerror = (event: { error?: Error }) => {
+      this.#emitter.emit("error", event.error ?? new Error("WebSocket error"));
     };
     this.#ws.onopen = (_event) => {
       if (this.#ws.protocol !== FoxgloveClient.SUPPORTED_SUBPROTOCOL) {


### PR DESCRIPTION
### Changelog
EventEmitter always emits values of `Error` types on "error", not `undefined`.

### Description

According to [the documentation of ws module for Node.js](https://github.com/websockets/ws/blob/HEAD/doc/ws.md#event-error), onerror handler emits `Error` types.
However, WebSocket in the browser does not emits `event.error`. This behavior is incorrect as per the code below.

https://github.com/foxglove/ws-protocol/blob/736c8dfc9256453a7ac017a823f308fd580571d2/typescript/ws-protocol/src/FoxgloveClient.ts#L29

I fixed to always emits values of `Error` types on "error".