### PR TITLE
Add operation `serviceCallFailure` to communicate failure of calling a service

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -298,7 +298,7 @@ Informs the client about updates to the connection graph. This is only sent to c
 }
 ```
 
-### Service call failure
+### Service Call Failure
 
 Informs the client about failure to [call a service](#service-call-request).
 Only supported if the server previously declared that it has the `services` [capability](#server-info).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -35,6 +35,7 @@
 - [Service Call Response](#service-call-response) (binary)
 - [Connection Graph Update](#connection-graph-update) (json)
 - [Fetch Asset Response](#fetch-asset-response) (binary)
+- [Service Call Failure](#service-call-failure) (json)
 
 ### Sent by client
 
@@ -294,6 +295,29 @@ Informs the client about updates to the connection graph. This is only sent to c
   "advertisedServices": [{ "name": "/set_bool", "providerIds": ["/node_2"] }],
   "removedTopics": ["/baz"],
   "removedServices": []
+}
+```
+
+### Service call failure
+
+Informs the client about failure to [call a service](#service-call-request).
+Only supported if the server previously declared that it has the `services` [capability](#server-info).
+
+#### Fields
+
+- `op`: string `"serviceCallFailure"`
+- `serviceId`: number
+- `callId`: number
+- `message`: string
+
+#### Example
+
+```json
+{
+  "op": "serviceCallFailure",
+  "serviceId": 1,
+  "callId": 1,
+  "message": "Service does not exist",
 }
 ```
 
@@ -574,6 +598,7 @@ All integer types explicitly specified (uint32, uint64, etc.) in this section ar
 ### Service Call Response
 
 - Provides the response to a previous [service call](#service-call-request).
+- If the service call failed, a [service call failure](#service-call-failure) response will be sent instead.
 - Only supported if the server previously declared the `services` [capability](#server-info).
 
 | Bytes             | Type    | Description                                           |

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-websocket
-version = 0.1.2
+version = 0.1.3
 description = Foxglove WebSocket server
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/typescript/ws-protocol-examples/src/examples/service-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-client.ts
@@ -73,6 +73,11 @@ async function main(url: string) {
 
     client.close();
   });
+
+  client.on("serviceCallFailure", (event) => {
+    console.error(`Failed to call service ${event.serviceId}: ${event.message}`);
+    client.close();
+  });
 }
 
 export default new Command("service-client")

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -17,6 +17,7 @@ import {
   ParameterValues,
   ServerMessage,
   Service,
+  ServiceCallFailure,
   ServiceCallPayload,
   ServiceCallResponse,
   ServiceId,
@@ -41,6 +42,7 @@ type EventTypes = {
   serviceCallResponse: (event: ServiceCallResponse) => void;
   connectionGraphUpdate: (event: ConnectionGraphUpdate) => void;
   fetchAssetResponse: (event: FetchAssetResponse) => void;
+  serviceCallFailure: (event: ServiceCallFailure) => void;
 };
 
 const textEncoder = new TextEncoder();
@@ -130,6 +132,10 @@ export default class FoxgloveClient {
 
         case "connectionGraphUpdate":
           this.#emitter.emit("connectionGraphUpdate", message);
+          return;
+
+        case "serviceCallFailure":
+          this.#emitter.emit("serviceCallFailure", message);
           return;
 
         case BinaryOpcode.MESSAGE_DATA:

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -235,6 +235,12 @@ export type FetchAssetErrorResponse = {
   error: string;
 };
 export type FetchAssetResponse = FetchAssetSuccessResponse | FetchAssetErrorResponse;
+export type ServiceCallFailure = {
+  op: "serviceCallFailure";
+  serviceId: number;
+  callId: number;
+  message: string;
+};
 export type ClientPublish = {
   channel: ClientChannel;
   data: DataView;
@@ -264,7 +270,8 @@ export type ServerMessage =
   | ServiceCallResponse
   | ParameterValues
   | ConnectionGraphUpdate
-  | FetchAssetResponse;
+  | FetchAssetResponse
+  | ServiceCallFailure;
 
 /**
  * Abstraction that supports both browser and Node WebSocket clients.


### PR DESCRIPTION
### Changelog
Add operation `serviceCallFailure` to communicate failure of calling a service

### Description
The current spec lacks a way to communicate the failure of calling a service. This PR changes that by adding a new operation which serves that purpose.