### PR TITLE
typescript: Add sendServiceCallFailure to server impl

### DIFF
--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -19,6 +19,7 @@ import {
   ServerCapability,
   ServerMessage,
   Service,
+  ServiceCallFailure,
   ServiceCallPayload,
   ServiceCallRequest,
   ServiceId,
@@ -271,6 +272,15 @@ export default class FoxgloveServer {
       offset,
     );
     connection.send(payload);
+  }
+
+  /**
+   * Send a service call failure response to the client
+   * @param response Response to send to the client
+   * @param connection Connection of the client that called the service
+   */
+  sendServiceCallFailure(response: ServiceCallFailure, connection: IWebSocket): void {
+    this.#send(connection, response);
   }
 
   /**


### PR DESCRIPTION
### Changelog
Typescript: Add function `sendServiceCallFailure` to send service call failure to client

### Description
Forgot to add that in #733
