### PR TITLE
mcap-record: chunk size and compression options

### DIFF
--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -68,7 +68,7 @@
     "@foxglove/schemas": "^1.6.2",
     "@foxglove/wasm-lz4": "^1.0.2",
     "@foxglove/wasm-zstd": "^1.0.1",
-    "@foxglove/ws-protocol": "0.7.2",
+    "@foxglove/ws-protocol": "0.7.3",
     "@mcap/core": "^2.0.0",
     "boxen": "^7.1.1",
     "commander": "^11.1.0",

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol-examples",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Foxglove WebSocket protocol examples",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol-examples/src/examples/mcap-record.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-record.ts
@@ -77,7 +77,13 @@ async function waitForServer(
 
 async function main(
   address: string,
-  options: { output: string; compression: boolean; queueSize: number },
+  options: {
+    output: string;
+    compression: boolean;
+    chunkSize: number;
+    compressionLevel: number;
+    queueSize: number;
+  },
 ): Promise<void> {
   await Zstd.isLoaded;
   await fs.mkdir(path.dirname(options.output), { recursive: true });
@@ -91,10 +97,11 @@ async function main(
 
   const writer = new McapWriter({
     writable: fileHandleWritable,
+    chunkSize: options.chunkSize,
     compressChunk: options.compression
       ? (data) => ({
           compression: "zstd",
-          compressedData: Zstd.compress(data, 19),
+          compressedData: Zstd.compress(data, options.compressionLevel),
         })
       : undefined,
   });
@@ -175,18 +182,24 @@ async function main(
             }
             const schemaId =
               schemaData != undefined && schemaEncoding != undefined
-                ? await writer.registerSchema({
-                    name: channel.schemaName,
-                    encoding: schemaEncoding,
-                    data: schemaData,
-                  })
+                ? await writeMsgQueue.add(
+                    async () =>
+                      await writer.registerSchema({
+                        name: channel.schemaName,
+                        encoding: schemaEncoding,
+                        data: schemaData,
+                      }),
+                  )
                 : 0;
-            const mcapChannelId = (await writer.registerChannel({
-              schemaId,
-              topic: channel.topic,
-              messageEncoding: channel.encoding,
-              metadata: new Map(),
-            })) as McapChannelId;
+            const mcapChannelId = (await writeMsgQueue.add(
+              async () =>
+                await writer.registerChannel({
+                  schemaId,
+                  topic: channel.topic,
+                  messageEncoding: channel.encoding,
+                  metadata: new Map(),
+                }),
+            )) as McapChannelId;
             wsChannelsByMcapChannel.set(mcapChannelId, channel.id as WsChannelId);
 
             log("subscribing to %s", channel.topic);
@@ -242,6 +255,8 @@ export default new Command("mcap-record")
   .argument("<address>", "WebSocket address, e.g. ws://localhost:8765")
   .option("-o, --output <file>", "path to write MCAP file")
   .option("-n, --no-compression", "do not compress chunks")
+  .option("--chunk-size <value>", "chunk size in bytes", parseInt, 5 * 1024 * 1024)
+  .option("--compression-level <value>", "Zstandard compression level", parseInt, 3)
   .option(
     "-q, --queue-size <value>",
     "Size of incoming message queue. Choose 0 for unlimited queue length (default)",

--- a/typescript/ws-protocol-examples/src/examples/mcap-record.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-record.ts
@@ -180,17 +180,20 @@ async function main(
               case undefined:
                 break;
             }
-            const schemaId =
-              schemaData != undefined && schemaEncoding != undefined
-                ? await writeMsgQueue.add(
-                    async () =>
-                      await writer.registerSchema({
-                        name: channel.schemaName,
-                        encoding: schemaEncoding,
-                        data: schemaData,
-                      }),
-                  )
-                : 0;
+            let schemaId = 0;
+            if (schemaData != undefined && schemaEncoding != undefined) {
+              // workaround to help TS type refinement
+              const nonnullSchemaData = schemaData;
+              const nonnullSchemaEncoding = schemaEncoding;
+              schemaId = await writeMsgQueue.add(
+                async () =>
+                  await writer.registerSchema({
+                    name: channel.schemaName,
+                    encoding: nonnullSchemaEncoding,
+                    data: nonnullSchemaData,
+                  }),
+              );
+            }
             const mcapChannelId = (await writeMsgQueue.add(
               async () =>
                 await writer.registerChannel({

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,15 +796,6 @@
   resolved "https://registry.yarnpkg.com/@foxglove/wasm-zstd/-/wasm-zstd-1.0.1.tgz#41f97f9c1ed5d10790603376fbecda7ce2145fe5"
   integrity sha512-hqKTO45Sl+kSq9SDqM9xi5L+GncjFEZIJgYEkGTlpJXTfhy1Gf+a+3epWMcE0tLUKmzM77dtu8snape/J+7ueQ==
 
-"@foxglove/ws-protocol@0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@foxglove/ws-protocol/-/ws-protocol-0.7.2.tgz#e9cdb2ea0181d2b197fd008d02b36b2733950c6e"
-  integrity sha512-HBRh9h8GVpBAxieQM8cD6OX4FSDM+t0mHgNjr8/nlls93hKblFuFDfqeHWgApht8qdG5wY36KgJ7KOLH52nHmA==
-  dependencies:
-    debug "^4"
-    eventemitter3 "^5.0.1"
-    tslib "^2.6.2"
-
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.13.tgz#075dc9684f40a531d9b26b0822153c1e832ee297"

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,6 +796,15 @@
   resolved "https://registry.yarnpkg.com/@foxglove/wasm-zstd/-/wasm-zstd-1.0.1.tgz#41f97f9c1ed5d10790603376fbecda7ce2145fe5"
   integrity sha512-hqKTO45Sl+kSq9SDqM9xi5L+GncjFEZIJgYEkGTlpJXTfhy1Gf+a+3epWMcE0tLUKmzM77dtu8snape/J+7ueQ==
 
+"@foxglove/ws-protocol@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@foxglove/ws-protocol/-/ws-protocol-0.7.2.tgz#e9cdb2ea0181d2b197fd008d02b36b2733950c6e"
+  integrity sha512-HBRh9h8GVpBAxieQM8cD6OX4FSDM+t0mHgNjr8/nlls93hKblFuFDfqeHWgApht8qdG5wY36KgJ7KOLH52nHmA==
+  dependencies:
+    debug "^4"
+    eventemitter3 "^5.0.1"
+    tslib "^2.6.2"
+
 "@humanwhocodes/config-array@^0.11.13":
   version "0.11.13"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.13.tgz#075dc9684f40a531d9b26b0822153c1e832ee297"


### PR DESCRIPTION
### Changelog
The `mcap-record` command supports new options for customizing `--chunk-size` and `--compression-level`. The default compression level is lower, and the default chunk size is higher, which improves the ability to record high-frequency data.

### Docs

Self-documenting via `--help` :)

### Description

The default compression level was quite high and was slowing down the recording process.