### PR TITLE
Add function to send service call failure to C++ implementation

### DIFF
--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
@@ -101,6 +101,8 @@ public:
   virtual void broadcastTime(uint64_t timestamp) = 0;
   virtual void sendServiceResponse(ConnectionHandle clientHandle,
                                    const ServiceResponse& response) = 0;
+  virtual void sendServiceFailure(ConnectionHandle clientHandle, ServiceId serviceId,
+                                  uint32_t callId, const std::string& message) = 0;
   virtual void updateConnectionGraph(const MapOfSets& publishedTopics,
                                      const MapOfSets& subscribedTopics,
                                      const MapOfSets& advertisedServices) = 0;

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -149,6 +149,8 @@ public:
                            const std::string& message);
   void broadcastTime(uint64_t timestamp) override;
   void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) override;
+  void sendServiceFailure(ConnHandle clientHandle, ServiceId serviceId, uint32_t callId,
+                          const std::string& message) override;
   void updateConnectionGraph(const MapOfSets& publishedTopics, const MapOfSets& subscribedTopics,
                              const MapOfSets& advertisedServices) override;
   void sendFetchAssetResponse(ConnHandle clientHandle, const FetchAssetResponse& response) override;
@@ -770,8 +772,10 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
     case ClientBinaryOpcode::SERVICE_CALL_REQUEST: {
       ServiceRequest request;
       if (length < request.size()) {
-        sendStatusAndLogMsg(hdl, StatusLevel::Error,
-                            "Invalid service call request length " + std::to_string(length));
+        const std::string errMessage =
+          "Invalid service call request length " + std::to_string(length);
+        sendServiceFailure(hdl, request.serviceId, request.callId, errMessage);
+        sendStatusAndLogMsg(hdl, StatusLevel::Error, errMessage);
         return;
       }
 
@@ -780,15 +784,23 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
       {
         std::shared_lock<std::shared_mutex> lock(_servicesMutex);
         if (_services.find(request.serviceId) == _services.end()) {
-          sendStatusAndLogMsg(
-            hdl, StatusLevel::Error,
-            "Service " + std::to_string(request.serviceId) + " is not advertised");
+          const std::string errMessage =
+            "Service " + std::to_string(request.serviceId) + " is not advertised";
+          sendServiceFailure(hdl, request.serviceId, request.callId, errMessage);
+          sendStatusAndLogMsg(hdl, StatusLevel::Error, errMessage);
           return;
         }
       }
 
-      if (_handlers.serviceRequestHandler) {
+      try {
+        if (!_handlers.serviceRequestHandler) {
+          throw foxglove::ServiceError(request.serviceId, "No service handler");
+        }
+
         _handlers.serviceRequestHandler(request, hdl);
+      } catch (const std::exception& e) {
+        sendServiceFailure(hdl, request.serviceId, request.callId, e.what());
+        sendStatusAndLogMsg(hdl, StatusLevel::Error, e.what());
       }
     } break;
     default: {
@@ -1045,6 +1057,16 @@ inline uint16_t Server<ServerConfiguration>::getPort() {
   }
   return endpoint.port();
 }
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendServiceFailure(ConnHandle clientHandle,
+                                                            ServiceId serviceId, uint32_t callId,
+                                                            const std::string& message) {
+  sendJson(clientHandle, json{{"op", "serviceCallFailure"},
+                              {"serviceId", serviceId},
+                              {"callId", callId},
+                              {"message", message}});
+};
 
 template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::updateConnectionGraph(


### PR DESCRIPTION
### Changelog
Add function to send service call failure to C++ implementation

### Description
In #733 we have added an additional operation to communicate service call failures to the client. This PR adds the corresponding function `sendServiceFailure` to the C++ implementation. 