### PR TITLE
mcap-record: Avoid duplicate subscription to channel

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/mcap-record.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-record.ts
@@ -129,7 +129,7 @@ async function main(
         SubscriptionId,
         { messageCount: number; mcapChannelId: McapChannelId }
       >();
-      const knownChannelIds = new Set<WsChannelId>();
+      const activeChannelIds = new Set<WsChannelId>();
 
       client.on("serverInfo", (event) => {
         log(event);
@@ -144,7 +144,7 @@ async function main(
       client.on("advertise", (newChannels) => {
         void Promise.all(
           newChannels.map(async (channel) => {
-            if (knownChannelIds.has(channel.id as WsChannelId)) {
+            if (activeChannelIds.has(channel.id as WsChannelId)) {
               log(
                 "skipping channel %d on topic %s as a channel with the same id has been advertised before.",
                 channel.id,
@@ -152,7 +152,7 @@ async function main(
               );
               return;
             }
-            knownChannelIds.add(channel.id as WsChannelId);
+            activeChannelIds.add(channel.id as WsChannelId);
 
             let schemaEncoding = channel.schemaEncoding;
             if (schemaEncoding == undefined) {
@@ -226,7 +226,7 @@ async function main(
       client.on("unadvertise", (channelIds) => {
         for (const channelId of channelIds) {
           log("channel %d has been unadvertised", channelId);
-          knownChannelIds.delete(channelId as WsChannelId);
+          activeChannelIds.delete(channelId as WsChannelId);
         }
       });
 


### PR DESCRIPTION
### Changelog
Fix `mcap-record` creating duplicated channels if existing channels are re-advertised by the server

### Docs
None

### Description
Logs a message when the server erroneously re-advertises channels which have been advertised before. As per the [spec](https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#advertise), only new channels should be advertised by the server but unfortunately not all servers comply with that. This extra check makes sure that channels are not duplicated in the resulting MCAP file.
