### PR TITLE
mcap-play: fix flatbuffer schema encoding

### DIFF
--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol-examples",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Foxglove WebSocket protocol examples",
   "keywords": [
     "foxglove",

--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -101,7 +101,7 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
   const mcapChannelsByWsChannel = new Map<WsChannelId, McapChannelId>();
   const wsChannelsByMcapChannel = new Map<McapChannelId, WsChannelId>();
   const subscribedChannels = new Set<WsChannelId>();
-  const skippedChannelIds = new Set<number>();
+  const skippedChannelIds = new Set<McapChannelId>();
 
   let running = false;
   const runLoop = async () => {
@@ -151,7 +151,7 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
                   schema.encoding,
                   record.id,
                 );
-                skippedChannelIds.add(record.id);
+                skippedChannelIds.add(record.id as McapChannelId);
                 continue;
             }
             const wsChannelId = server.addChannel({
@@ -168,7 +168,7 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
           case "Message": {
             const wsChannelId = wsChannelsByMcapChannel.get(record.channelId as McapChannelId);
             if (wsChannelId == undefined) {
-              if (!skippedChannelIds.has(record.channelId)) {
+              if (!skippedChannelIds.has(record.channelId as McapChannelId)) {
                 log("Message on unknown channel %d", record.channelId);
               }
               break;

--- a/typescript/ws-protocol-examples/src/examples/mcap-play.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-play.ts
@@ -101,6 +101,7 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
   const mcapChannelsByWsChannel = new Map<WsChannelId, McapChannelId>();
   const wsChannelsByMcapChannel = new Map<McapChannelId, WsChannelId>();
   const subscribedChannels = new Set<WsChannelId>();
+  const skippedChannelIds = new Set<number>();
 
   let running = false;
   const runLoop = async () => {
@@ -131,15 +132,34 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
               log("Channel %d has unknown schema %d", record.id, record.schemaId);
               break;
             }
+            let schemaData: string;
+            switch (schema.encoding) {
+              case "ros1msg":
+              case "ros2msg":
+              case "ros2idl":
+              case "omgidl":
+              case "jsonschema":
+                schemaData = new TextDecoder().decode(schema.data);
+                break;
+              case "protobuf":
+              case "flatbuffer":
+                schemaData = Buffer.from(schema.data).toString("base64");
+                break;
+              default:
+                log(
+                  "Unknown schema encoding %s for channel %d, skipping",
+                  schema.encoding,
+                  record.id,
+                );
+                skippedChannelIds.add(record.id);
+                continue;
+            }
             const wsChannelId = server.addChannel({
               topic: record.topic,
               schemaName: schema.name,
               encoding: record.messageEncoding,
               schemaEncoding: schema.encoding,
-              schema:
-                schema.encoding === "protobuf"
-                  ? Buffer.from(schema.data).toString("base64")
-                  : new TextDecoder().decode(schema.data),
+              schema: schemaData,
             }) as WsChannelId;
             mcapChannelsByWsChannel.set(wsChannelId, record.id as McapChannelId);
             wsChannelsByMcapChannel.set(record.id as McapChannelId, wsChannelId);
@@ -148,7 +168,9 @@ async function main(file: string, options: { loop: boolean; rate: number }): Pro
           case "Message": {
             const wsChannelId = wsChannelsByMcapChannel.get(record.channelId as McapChannelId);
             if (wsChannelId == undefined) {
-              log("Message on unknown channel %d", record.channelId);
+              if (!skippedChannelIds.has(record.channelId)) {
+                log("Message on unknown channel %d", record.channelId);
+              }
               break;
             }
 


### PR DESCRIPTION
### Changelog
Added support for flatbuffer schemas in `mcap-play`.

### Docs

None

### Description

We were only base64-encoding data for protobuf schemas, but needed to do this for flatbuffer as well. Added an error message to ensure we don't get this wrong for any future encodings, but skip the unknown encoding.