### PR TITLE
remove support for node 16.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [ws-protocol, ws-protocol-examples, test-client-web-app]
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/typescript/ws-protocol-examples/package.json
+++ b/typescript/ws-protocol-examples/package.json
@@ -19,7 +19,7 @@
     "email": "support@foxglove.dev"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "homepage": "https://foxglove.dev/",
   "module": "dist/esm/ws-protocol-examples/src/index.js",


### PR DESCRIPTION
### Changelog
Remove support for node 16.x

### Docs
None

### Description
Node 16 is EOL and not supported anymore. This PR removes the node 16.x CI check and requires at least node 18 to run the `@foxglove/ws-protocol-examples` scripts.

See also https://github.com/foxglove/ws-protocol/pull/776#issuecomment-2228205157

