### PR TITLE
Add support for clearing previously sent status messages

### DIFF
--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
@@ -76,6 +76,18 @@ struct ServerHandlers {
   std::function<void(const std::string&, uint32_t, ConnectionHandle)> fetchAssetHandler;
 };
 
+enum class StatusLevel : uint8_t {
+  Info = 0,
+  Warning = 1,
+  Error = 2,
+};
+
+struct Status {
+  StatusLevel level;
+  std::string message;
+  std::optional<std::string> id = std::nullopt;
+};
+
 template <typename ConnectionHandle>
 class ServerInterface {
 public:
@@ -108,6 +120,8 @@ public:
                                      const MapOfSets& advertisedServices) = 0;
   virtual void sendFetchAssetResponse(ConnectionHandle clientHandle,
                                       const FetchAssetResponse& response) = 0;
+  virtual void sendStatus(const Status& status) = 0;
+  virtual void clearStatus(const std::vector<std::string>& statusIds) = 0;
 
   virtual uint16_t getPort() = 0;
   virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;

--- a/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/server_interface.hpp
@@ -121,7 +121,7 @@ public:
   virtual void sendFetchAssetResponse(ConnectionHandle clientHandle,
                                       const FetchAssetResponse& response) = 0;
   virtual void sendStatus(const Status& status) = 0;
-  virtual void clearStatus(const std::vector<std::string>& statusIds) = 0;
+  virtual void removeStatus(const std::vector<std::string>& statusIds) = 0;
 
   virtual uint16_t getPort() = 0;
   virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -151,7 +151,7 @@ public:
   void sendFetchAssetResponse(ConnHandle clientHandle, const FetchAssetResponse& response) override;
   void sendStatus(ConnHandle clientHandle, const Status& status);
   void sendStatus(const Status& status) override;
-  void clearStatus(const std::vector<std::string>& statusIds) override;
+  void removeStatus(const std::vector<std::string>& statusIds) override;
 
   uint16_t getPort() override;
   std::string remoteEndpointString(ConnHandle clientHandle) override;
@@ -1554,12 +1554,12 @@ inline void Server<ServerConfiguration>::sendStatus(const Status& status) {
 }
 
 template <typename ServerConfiguration>
-inline void Server<ServerConfiguration>::clearStatus(const std::vector<std::string>& statusIds) {
+inline void Server<ServerConfiguration>::removeStatus(const std::vector<std::string>& statusIds) {
   std::shared_lock<std::shared_mutex> lock(_clientsMutex);
   for (const auto& [hdl, clientInfo] : _clients) {
     (void)clientInfo;
     sendJson(hdl, json{
-                    {"op", "clearStatus"},
+                    {"op", "removeStatus"},
                     {"statusIds", statusIds},
                   });
   }

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -93,12 +93,6 @@ const std::unordered_map<ClientBinaryOpcode, std::string> CAPABILITY_BY_CLIENT_B
   {ClientBinaryOpcode::SERVICE_CALL_REQUEST, CAPABILITY_SERVICES},
 };
 
-enum class StatusLevel : uint8_t {
-  Info = 0,
-  Warning = 1,
-  Error = 2,
-};
-
 constexpr websocketpp::log::level StatusLevelToLogLevel(StatusLevel level) {
   switch (level) {
     case StatusLevel::Info:
@@ -146,7 +140,8 @@ public:
   void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
                    const uint8_t* payload, size_t payloadSize) override;
   void sendStatusAndLogMsg(ConnHandle clientHandle, const StatusLevel level,
-                           const std::string& message);
+                           const std::string& message,
+                           const std::optional<std::string>& id = std::nullopt);
   void broadcastTime(uint64_t timestamp) override;
   void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) override;
   void sendServiceFailure(ConnHandle clientHandle, ServiceId serviceId, uint32_t callId,
@@ -154,13 +149,12 @@ public:
   void updateConnectionGraph(const MapOfSets& publishedTopics, const MapOfSets& subscribedTopics,
                              const MapOfSets& advertisedServices) override;
   void sendFetchAssetResponse(ConnHandle clientHandle, const FetchAssetResponse& response) override;
+  void sendStatus(ConnHandle clientHandle, const Status& status);
+  void sendStatus(const Status& status) override;
+  void clearStatus(const std::vector<std::string>& statusIds) override;
 
   uint16_t getPort() override;
   std::string remoteEndpointString(ConnHandle clientHandle) override;
-
-  typename ServerType::endpoint_type& getEndpoint() & {
-    return _server;
-  }
 
 private:
   struct ClientInfo {
@@ -592,20 +586,32 @@ inline void Server<ServerConfiguration>::sendBinary(ConnHandle hdl, const uint8_
 }
 
 template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendStatus(ConnHandle clientHandle, const Status& status) {
+  json statusPayload = {
+    {"op", "status"},
+    {"level", static_cast<uint8_t>(status.level)},
+    {"message", status.message},
+  };
+
+  if (status.id) {
+    statusPayload["id"] = status.id.value();
+  }
+
+  sendJson(clientHandle, std::move(statusPayload));
+}
+
+template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::sendStatusAndLogMsg(ConnHandle clientHandle,
                                                              const StatusLevel level,
-                                                             const std::string& message) {
+                                                             const std::string& message,
+                                                             const std::optional<std::string>& id) {
   const std::string endpoint = remoteEndpointString(clientHandle);
   const std::string logMessage = endpoint + ": " + message;
   const auto logLevel = StatusLevelToLogLevel(level);
   auto logger = level == StatusLevel::Info ? _server.get_alog() : _server.get_elog();
   logger.write(logLevel, logMessage);
 
-  sendJson(clientHandle, json{
-                           {"op", "status"},
-                           {"level", static_cast<uint8_t>(level)},
-                           {"message", message},
-                         });
+  sendStatus(clientHandle, {level, message, id});
 }
 
 template <typename ServerConfiguration>
@@ -1066,7 +1072,7 @@ inline void Server<ServerConfiguration>::sendServiceFailure(ConnHandle clientHan
                               {"serviceId", serviceId},
                               {"callId", callId},
                               {"message", message}});
-};
+}
 
 template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::updateConnectionGraph(
@@ -1536,6 +1542,27 @@ inline void Server<ServerConfiguration>::sendFetchAssetResponse(
 
   message->append_payload(response.data.data(), dataSize);
   con->send(message);
+}
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendStatus(const Status& status) {
+  std::shared_lock<std::shared_mutex> lock(_clientsMutex);
+  for (const auto& [hdl, clientInfo] : _clients) {
+    (void)clientInfo;
+    sendStatus(hdl, status);
+  }
+}
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::clearStatus(const std::vector<std::string>& statusIds) {
+  std::shared_lock<std::shared_mutex> lock(_clientsMutex);
+  for (const auto& [hdl, clientInfo] : _clients) {
+    (void)clientInfo;
+    sendJson(hdl, json{
+                    {"op", "clearStatus"},
+                    {"statusIds", statusIds},
+                  });
+  }
 }
 
 }  // namespace foxglove

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -25,7 +25,7 @@
 
 - [Server Info](#server-info) (json)
 - [Status](#status) (json)
-- [Clear Status](#clear-status) (json)
+- [Remove Status](#remove-status) (json)
 - [Advertise](#advertise) (json)
 - [Unadvertise](#unadvertise) (json)
 - [Message Data](#message-data) (binary)
@@ -102,7 +102,7 @@ Each JSON message must be an object containing a field called `op` which identif
 - `op`: string `"status"`
 - `level`: 0 (info), 1 (warning), 2 (error)
 - `message`: string
-- `id`: string | undefined. Optional identifier for the status message. Newer status messages with the same identifier should replace previous messages. [clearStatus](#clear-status) can reference the identifier to indicate a status message is no longer valid.
+- `id`: string | undefined. Optional identifier for the status message. Newer status messages with the same identifier should replace previous messages. [removeStatus](#remove-status) can reference the identifier to indicate a status message is no longer valid.
 
 #### Example
 
@@ -115,20 +115,20 @@ Each JSON message must be an object containing a field called `op` which identif
 }
 ```
 
-### Clear Status
+### Remove Status
 
 - Informs the client that previously sent status message(s) are no longer valid.
 
 #### Fields
 
-- `op`: string `"clearStatus"`
-- `statusIds`: array of string, ids of the status messages to be cleared. The array must not be empty.
+- `op`: string `"removeStatus"`
+- `statusIds`: array of string, ids of the status messages to be removed. The array must not be empty.
 
 #### Example
 
 ```json
 {
-  "op": "clearStatus",
+  "op": "removeStatus",
   "statusIds": ["status-123"]
 }
 ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -102,7 +102,7 @@ Each JSON message must be an object containing a field called `op` which identif
 - `op`: string `"status"`
 - `level`: 0 (info), 1 (warning), 2 (error)
 - `message`: string
-- `id`: string | undefined. Optional unique identifier that can be used for clearing the status.
+- `id`: string | undefined. Optional identifier for the status message. Newer status messages with the same identifier should replace previous messages. [clearStatus](#clear-status) can reference the identifier to indicate a status message is no longer valid.
 
 #### Example
 
@@ -111,25 +111,25 @@ Each JSON message must be an object containing a field called `op` which identif
   "op": "status",
   "level": 0,
   "message": "Some info",
-  "id": "someId"
+  "id": "status-123"
 }
 ```
 
 ### Clear Status
 
-- Informs the client that a previously sent status message shall be cleared.
+- Informs the client that previously sent status message(s) are no longer valid.
 
 #### Fields
 
 - `op`: string `"clearStatus"`
-- `id`: string, the id of the status message to be cleared.
+- `statusIds`: array of string, ids of the status messages to be cleared. The array must not be empty.
 
 #### Example
 
 ```json
 {
   "op": "clearStatus",
-  "id": "someId"
+  "statusIds": ["status-123"]
 }
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -25,6 +25,7 @@
 
 - [Server Info](#server-info) (json)
 - [Status](#status) (json)
+- [Clear Status](#clear-status) (json)
 - [Advertise](#advertise) (json)
 - [Unadvertise](#unadvertise) (json)
 - [Message Data](#message-data) (binary)
@@ -101,6 +102,7 @@ Each JSON message must be an object containing a field called `op` which identif
 - `op`: string `"status"`
 - `level`: 0 (info), 1 (warning), 2 (error)
 - `message`: string
+- `id`: string | undefined. Optional unique identifier that can be used for clearing the status.
 
 #### Example
 
@@ -108,7 +110,26 @@ Each JSON message must be an object containing a field called `op` which identif
 {
   "op": "status",
   "level": 0,
-  "message": "Some info"
+  "message": "Some info",
+  "id": "someId"
+}
+```
+
+### Clear Status
+
+- Informs the client that a previously sent status message shall be cleared.
+
+#### Fields
+
+- `op`: string `"clearStatus"`
+- `id`: string, the id of the status message to be cleared.
+
+#### Example
+
+```json
+{
+  "op": "clearStatus",
+  "id": "someId"
 }
 ```
 

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -455,7 +455,11 @@ class FoxgloveServer:
                             await result
 
     async def _send_status(
-        self, connection: WebSocketServerProtocol, level: StatusLevel, msg: str, id: Optional[str] = None
+        self,
+        connection: WebSocketServerProtocol,
+        level: StatusLevel,
+        msg: str,
+        id: Optional[str] = None,
     ) -> None:
         await self._send_json(
             connection,

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -349,6 +349,20 @@ class FoxgloveServer:
             except ConnectionClosed:
                 pass
 
+    async def send_status(self, level: StatusLevel, msg: str, id: Optional[str] = None):
+        for client in self._clients:
+            try:
+                await self._send_status(client.connection, level, msg, id)
+            except ConnectionClosed:
+                pass
+
+    async def clear_status(self, statusIds: List[str]):
+        for client in self._clients:
+            try:
+                await self._clear_status(client.connection, statusIds)
+            except ConnectionClosed:
+                pass
+
     async def _send_json(
         self, connection: WebSocketServerProtocol, msg: ServerJsonMessage
     ):
@@ -441,7 +455,7 @@ class FoxgloveServer:
                             await result
 
     async def _send_status(
-        self, connection: WebSocketServerProtocol, level: StatusLevel, msg: str
+        self, connection: WebSocketServerProtocol, level: StatusLevel, msg: str, id: Optional[str] = None
     ) -> None:
         await self._send_json(
             connection,
@@ -449,6 +463,18 @@ class FoxgloveServer:
                 "op": "status",
                 "level": level,
                 "message": msg,
+                "id": id,
+            },
+        )
+
+    async def _clear_status(
+        self, connection: WebSocketServerProtocol, statusIds: List[str]
+    ) -> None:
+        await self._send_json(
+            connection,
+            {
+                "op": "clearStatus",
+                "statusIds": statusIds,
             },
         )
 

--- a/python/src/foxglove_websocket/server/__init__.py
+++ b/python/src/foxglove_websocket/server/__init__.py
@@ -356,10 +356,10 @@ class FoxgloveServer:
             except ConnectionClosed:
                 pass
 
-    async def clear_status(self, statusIds: List[str]):
+    async def remove_status(self, statusIds: List[str]):
         for client in self._clients:
             try:
-                await self._clear_status(client.connection, statusIds)
+                await self._remove_status(client.connection, statusIds)
             except ConnectionClosed:
                 pass
 
@@ -471,13 +471,13 @@ class FoxgloveServer:
             },
         )
 
-    async def _clear_status(
+    async def _remove_status(
         self, connection: WebSocketServerProtocol, statusIds: List[str]
     ) -> None:
         await self._send_json(
             connection,
             {
-                "op": "clearStatus",
+                "op": "removeStatus",
                 "statusIds": statusIds,
             },
         )

--- a/python/src/foxglove_websocket/types.py
+++ b/python/src/foxglove_websocket/types.py
@@ -131,8 +131,8 @@ class StatusMessage(TypedDict):
     id: Optional[str]
 
 
-class ClearStatusMessages(TypedDict):
-    op: Literal["clearStatus"]
+class RemoveStatusMessages(TypedDict):
+    op: Literal["removeStatus"]
     statusIds: List[str]
 
 
@@ -201,7 +201,7 @@ class ParameterValues(TypedDict):
 ServerJsonMessage = Union[
     ServerInfo,
     StatusMessage,
-    ClearStatusMessages,
+    RemoveStatusMessages,
     Advertise,
     Unadvertise,
     AdvertiseServices,

--- a/python/src/foxglove_websocket/types.py
+++ b/python/src/foxglove_websocket/types.py
@@ -128,6 +128,12 @@ class StatusMessage(TypedDict):
     op: Literal["status"]
     level: StatusLevel
     message: str
+    id: Optional[str]
+
+
+class ClearStatusMessages(TypedDict):
+    op: Literal["clearStatus"]
+    statusIds: List[str]
 
 
 class ChannelWithoutId(TypedDict):
@@ -195,6 +201,7 @@ class ParameterValues(TypedDict):
 ServerJsonMessage = Union[
     ServerInfo,
     StatusMessage,
+    ClearStatusMessages,
     Advertise,
     Unadvertise,
     AdvertiseServices,

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -81,6 +81,7 @@ async def test_warn_invalid_channel():
                 "op": "status",
                 "level": 1,
                 "message": "Channel 999 is not available; ignoring subscription",
+                "id": None,
             }
 
 

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -162,7 +162,7 @@ async function main(): Promise<void> {
         id: "statusFoo",
       });
     } else {
-      server.clearStatus(["statusFoo"]);
+      server.removeStatus(["statusFoo"]);
     }
     callCount++;
   });

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -4,6 +4,7 @@ import {
   ServerCapability,
   Service,
   ServiceCallPayload,
+  StatusLevel,
 } from "@foxglove/ws-protocol";
 import { Command } from "commander";
 import Debug from "debug";
@@ -28,6 +29,8 @@ async function main(): Promise<void> {
     handleProtocols: (protocols) => server.handleProtocols(protocols),
   });
   setupSigintHandler(log, ws);
+
+  let callCount = 0;
 
   const serviceDefRos: Omit<Service, "id"> = {
     name: "/set_bool_ros",
@@ -125,7 +128,11 @@ async function main(): Promise<void> {
       throw err;
     }
 
-    log("Received service call request with %d bytes", request.data.byteLength);
+    log(
+      "Received service call request with %d bytes, call count %d",
+      request.data.byteLength,
+      callCount,
+    );
 
     const responseMsg = {
       success: true,
@@ -147,6 +154,17 @@ async function main(): Promise<void> {
       data: new DataView(responseData.buffer),
     };
     server.sendServiceCallResponse(response, clientConnection);
+
+    if (callCount % 2 === 0) {
+      server.sendStatus({
+        level: StatusLevel.INFO,
+        message: "Service was called :)",
+        id: "statusFoo",
+      });
+    } else {
+      server.clearStatus(["statusFoo"]);
+    }
+    callCount++;
   });
   server.on("error", (err) => {
     log("server error: %o", err);

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -5,6 +5,7 @@ import { parseServerMessage } from "./parse";
 import {
   BinaryOpcode,
   Channel,
+  ClearStatusMessage,
   ClientBinaryOpcode,
   ClientChannel,
   ClientChannelId,
@@ -32,6 +33,7 @@ type EventTypes = {
 
   serverInfo: (event: ServerInfo) => void;
   status: (event: StatusMessage) => void;
+  clearStatus: (event: ClearStatusMessage) => void;
   message: (event: MessageData) => void;
   time: (event: Time) => void;
   advertise: (newChannels: Channel[]) => void;
@@ -108,6 +110,10 @@ export default class FoxgloveClient {
 
         case "status":
           this.#emitter.emit("status", message);
+          return;
+
+        case "clearStatus":
+          this.#emitter.emit("clearStatus", message);
           return;
 
         case "advertise":

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -5,7 +5,7 @@ import { parseServerMessage } from "./parse";
 import {
   BinaryOpcode,
   Channel,
-  ClearStatusMessage,
+  ClearStatusMessages,
   ClientBinaryOpcode,
   ClientChannel,
   ClientChannelId,
@@ -33,7 +33,7 @@ type EventTypes = {
 
   serverInfo: (event: ServerInfo) => void;
   status: (event: StatusMessage) => void;
-  clearStatus: (event: ClearStatusMessage) => void;
+  clearStatus: (event: ClearStatusMessages) => void;
   message: (event: MessageData) => void;
   time: (event: Time) => void;
   advertise: (newChannels: Channel[]) => void;

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -5,7 +5,7 @@ import { parseServerMessage } from "./parse";
 import {
   BinaryOpcode,
   Channel,
-  ClearStatusMessages,
+  RemoveStatusMessages,
   ClientBinaryOpcode,
   ClientChannel,
   ClientChannelId,
@@ -33,7 +33,7 @@ type EventTypes = {
 
   serverInfo: (event: ServerInfo) => void;
   status: (event: StatusMessage) => void;
-  clearStatus: (event: ClearStatusMessages) => void;
+  removeStatus: (event: RemoveStatusMessages) => void;
   message: (event: MessageData) => void;
   time: (event: Time) => void;
   advertise: (newChannels: Channel[]) => void;
@@ -112,8 +112,8 @@ export default class FoxgloveClient {
           this.#emitter.emit("status", message);
           return;
 
-        case "clearStatus":
-          this.#emitter.emit("clearStatus", message);
+        case "removeStatus":
+          this.#emitter.emit("removeStatus", message);
           return;
 
         case "advertise":

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -681,21 +681,21 @@ export default class FoxgloveServer {
   }
 
   /**
-   * Clear a status for one or for all clients.
+   * Clear status message(s) for one or for all clients.
 
-   * @param id Id of the status to be cleared.
+   * @param statusIds Status ids to be cleared.
    * @param connection Optional connection. If undefined, the status will be cleared for all clients.
    */
-  clearStatus(id: string, connection?: IWebSocket): void {
+  clearStatus(statusIds: string[], connection?: IWebSocket): void {
     if (connection) {
       // Clear the status for a single client.
-      this.#send(connection, { op: "clearStatus", id });
+      this.#send(connection, { op: "clearStatus", statusIds });
       return;
     }
 
     // CLear status for all clients.
     for (const client of this.#clients.values()) {
-      this.#send(client.connection, { op: "clearStatus", id });
+      this.#send(client.connection, { op: "clearStatus", statusIds });
     }
   }
 }

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -23,6 +23,7 @@ import {
   ServiceCallPayload,
   ServiceCallRequest,
   ServiceId,
+  StatusMessage,
   SubscriptionId,
 } from "./types";
 
@@ -658,5 +659,43 @@ export default class FoxgloveServer {
     }
 
     connection.send(msg);
+  }
+
+  /**
+   * Send a status message to one or all clients.
+   *
+   * @param status Status message
+   * @param connection Optional connection. If undefined, the status message will be sent to all clients.
+   */
+  sendStatus(status: Omit<StatusMessage, "op">, connection?: IWebSocket): void {
+    if (connection) {
+      // Send the status to a single client.
+      this.#send(connection, { op: "status", ...status });
+      return;
+    }
+
+    // Send status message to all clients.
+    for (const client of this.#clients.values()) {
+      this.sendStatus(status, client.connection);
+    }
+  }
+
+  /**
+   * Clear a status for one or for all clients.
+
+   * @param id Id of the status to be cleared.
+   * @param connection Optional connection. If undefined, the status will be cleared for all clients.
+   */
+  clearStatus(id: string, connection?: IWebSocket): void {
+    if (connection) {
+      // Clear the status for a single client.
+      this.#send(connection, { op: "clearStatus", id });
+      return;
+    }
+
+    // CLear status for all clients.
+    for (const client of this.#clients.values()) {
+      this.#send(client.connection, { op: "clearStatus", id });
+    }
   }
 }

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -681,21 +681,21 @@ export default class FoxgloveServer {
   }
 
   /**
-   * Clear status message(s) for one or for all clients.
+   * Remove status message(s) for one or for all clients.
 
-   * @param statusIds Status ids to be cleared.
-   * @param connection Optional connection. If undefined, the status will be cleared for all clients.
+   * @param statusIds Status ids to be removed.
+   * @param connection Optional connection. If undefined, the status will be removed for all clients.
    */
-  clearStatus(statusIds: string[], connection?: IWebSocket): void {
+  removeStatus(statusIds: string[], connection?: IWebSocket): void {
     if (connection) {
-      // Clear the status for a single client.
-      this.#send(connection, { op: "clearStatus", statusIds });
+      // Remove status for a single client.
+      this.#send(connection, { op: "removeStatus", statusIds });
       return;
     }
 
-    // CLear status for all clients.
+    // Remove status for all clients.
     for (const client of this.#clients.values()) {
-      this.#send(client.connection, { op: "clearStatus", statusIds });
+      this.#send(client.connection, { op: "removeStatus", statusIds });
     }
   }
 }

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -143,8 +143,8 @@ export type StatusMessage = {
   message: string;
   id?: string;
 };
-export type ClearStatusMessages = {
-  op: "clearStatus";
+export type RemoveStatusMessages = {
+  op: "removeStatus";
   statusIds: string[];
 };
 export type Advertise = {
@@ -266,7 +266,7 @@ export type Parameter = {
 export type ServerMessage =
   | ServerInfo
   | StatusMessage
-  | ClearStatusMessages
+  | RemoveStatusMessages
   | Advertise
   | Unadvertise
   | AdvertiseServices

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -143,9 +143,9 @@ export type StatusMessage = {
   message: string;
   id?: string;
 };
-export type ClearStatusMessage = {
+export type ClearStatusMessages = {
   op: "clearStatus";
-  id: string;
+  statusIds: string[];
 };
 export type Advertise = {
   op: "advertise";
@@ -266,7 +266,7 @@ export type Parameter = {
 export type ServerMessage =
   | ServerInfo
   | StatusMessage
-  | ClearStatusMessage
+  | ClearStatusMessages
   | Advertise
   | Unadvertise
   | AdvertiseServices

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -141,6 +141,11 @@ export type StatusMessage = {
   op: "status";
   level: StatusLevel;
   message: string;
+  id?: string;
+};
+export type ClearStatusMessage = {
+  op: "clearStatus";
+  id: string;
 };
 export type Advertise = {
   op: "advertise";
@@ -261,6 +266,7 @@ export type Parameter = {
 export type ServerMessage =
   | ServerInfo
   | StatusMessage
+  | ClearStatusMessage
   | Advertise
   | Unadvertise
   | AdvertiseServices


### PR DESCRIPTION
### Changelog
Add support for clearing previously sent status messages

### Docs
None

### Description
Adds the `removeStatus` operation which can be used to clear a previously sent status message. To identify which status message shall be cleared, a `id` field has been added to the status message.

Adapted implementations:
- [x] typescript
- [x] c++
- [x] python
