### PR TITLE
Cpp: Fix incorrect exception being caught, fix docker warnings

### DIFF
--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -21,7 +21,7 @@ ENV CXX=clang++
 
 WORKDIR /src
 
-FROM base as build
+FROM base AS build
 RUN pip --no-cache-dir install conan
 RUN conan profile detect --force
 COPY ./foxglove-websocket /src/foxglove-websocket/
@@ -29,7 +29,7 @@ ARG CPPSTD=17
 ARG ASIO=standalone
 RUN conan create foxglove-websocket -s compiler.cppstd=$CPPSTD --build=missing -o foxglove-websocket*:asio=$ASIO
 
-FROM build as build_examples
+FROM build AS build_examples
 COPY --from=build /root/.conan2 /root/.conan2
 COPY ./examples /src/examples
 RUN conan build examples --output-folder examples/ -s compiler.cppstd=$CPPSTD --build=missing

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class FoxgloveWebSocketConan(ConanFile):
     name = "foxglove-websocket"
-    version = "1.2.0"
+    version = "1.1.0"
     url = "https://github.com/foxglove/ws-protocol"
     homepage = "https://github.com/foxglove/ws-protocol"
     description = "A C++ server implementation of the Foxglove WebSocket Protocol"

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 
 class FoxgloveWebSocketConan(ConanFile):
     name = "foxglove-websocket"
-    version = "1.1.0"
+    version = "1.2.0"
     url = "https://github.com/foxglove/ws-protocol"
     homepage = "https://github.com/foxglove/ws-protocol"
     description = "A C++ server implementation of the Foxglove WebSocket Protocol"

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -769,10 +769,10 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
                                           length,
                                           data};
         _handlers.clientMessageHandler(clientMessage, hdl);
-      } catch (const ServiceError& e) {
+      } catch (const ClientChannelError& e) {
         sendStatusAndLogMsg(hdl, StatusLevel::Error, e.what());
       } catch (...) {
-        sendStatusAndLogMsg(hdl, StatusLevel::Error, "callService: Failed to execute handler");
+        sendStatusAndLogMsg(hdl, StatusLevel::Error, "clientPublish: Failed to execute handler");
       }
     } break;
     case ClientBinaryOpcode::SERVICE_CALL_REQUEST: {


### PR DESCRIPTION
### Changelog
Cpp: Fix incorrect exception being caught, fix docker warnings #796

### Docs
None

### Description
- Fixes incorrect exception being caught (noticed that in https://github.com/foxglove/ros-foxglove-bridge/pull/307/commits/44abb8d6eaae72502067d106d6a01555d566224e)
- Fix docker warnings (`WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)`)
- ~Bumps conan recipe version~