### PR TITLE
Fix cpp compiler warnings

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -5,7 +5,12 @@ find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
 add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
-target_include_directories(foxglove_websocket PUBLIC include)
+target_include_directories(foxglove_websocket
+    PUBLIC include
+    SYSTEM
+    ${nlohmann_json_INCLUDE_DIRS}
+    ${websocketpp_INCLUDE_DIRS}
+)
 target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketpp::websocketpp)
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 

--- a/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
@@ -148,8 +148,8 @@ struct ServiceResponse {
   size_t size() const {
     return 4 + 4 + 4 + encoding.size() + data.size();
   }
-  void read(const uint8_t* data, size_t size);
-  void write(uint8_t* data) const;
+  void read(const uint8_t* payload, size_t payloadSize);
+  void write(uint8_t* payload) const;
 
   bool operator==(const ServiceResponse& other) const {
     return serviceId == other.serviceId && callId == other.callId && encoding == other.encoding &&

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -1536,7 +1536,7 @@ inline void Server<ServerConfiguration>::sendFetchAssetResponse(
   const uint8_t status = static_cast<uint8_t>(response.status);
   message->append_payload(&status, 1);
 
-  foxglove::WriteUint32LE(uint32Data.data(), response.errorMessage.size());
+  foxglove::WriteUint32LE(uint32Data.data(), static_cast<uint32_t>(response.errorMessage.size()));
   message->append_payload(uint32Data.data(), uint32Data.size());
   message->append_payload(response.errorMessage.data(), errMsgSize);
 

--- a/cpp/foxglove-websocket/src/serialization.cpp
+++ b/cpp/foxglove-websocket/src/serialization.cpp
@@ -157,32 +157,32 @@ void from_json(const nlohmann::json& j, ServiceRequestDefinition& r) {
   r.schema = j["schema"].get<std::string>();
 }
 
-void ServiceResponse::read(const uint8_t* data, size_t dataLength) {
+void ServiceResponse::read(const uint8_t* payload, size_t payloadSize) {
   size_t offset = 0;
-  this->serviceId = ReadUint32LE(data + offset);
+  this->serviceId = ReadUint32LE(payload + offset);
   offset += 4;
-  this->callId = ReadUint32LE(data + offset);
+  this->callId = ReadUint32LE(payload + offset);
   offset += 4;
-  const size_t encondingLength = static_cast<size_t>(ReadUint32LE(data + offset));
+  const size_t encondingLength = static_cast<size_t>(ReadUint32LE(payload + offset));
   offset += 4;
-  this->encoding = std::string(reinterpret_cast<const char*>(data + offset), encondingLength);
+  this->encoding = std::string(reinterpret_cast<const char*>(payload + offset), encondingLength);
   offset += encondingLength;
-  const auto payloadLength = dataLength - offset;
-  this->data.resize(payloadLength);
-  std::memcpy(this->data.data(), data + offset, payloadLength);
+  const auto dataSize = payloadSize - offset;
+  this->data.resize(dataSize);
+  std::memcpy(this->data.data(), payload + offset, dataSize);
 }
 
-void ServiceResponse::write(uint8_t* data) const {
+void ServiceResponse::write(uint8_t* payload) const {
   size_t offset = 0;
-  foxglove::WriteUint32LE(data + offset, this->serviceId);
+  foxglove::WriteUint32LE(payload + offset, this->serviceId);
   offset += 4;
-  foxglove::WriteUint32LE(data + offset, this->callId);
+  foxglove::WriteUint32LE(payload + offset, this->callId);
   offset += 4;
-  foxglove::WriteUint32LE(data + offset, static_cast<uint32_t>(this->encoding.size()));
+  foxglove::WriteUint32LE(payload + offset, static_cast<uint32_t>(this->encoding.size()));
   offset += 4;
-  std::memcpy(data + offset, this->encoding.data(), this->encoding.size());
+  std::memcpy(payload + offset, this->encoding.data(), this->encoding.size());
   offset += this->encoding.size();
-  std::memcpy(data + offset, this->data.data(), this->data.size());
+  std::memcpy(payload + offset, this->data.data(), this->data.size());
 }
 
 }  // namespace foxglove


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
- include websocketpp & nlohman_json as system libs to suppress compiler warnings
- fix conversion warning
- fix declaration hides class member warning