### PR TITLE
Only treat warnings as errors for CI builds

### DIFF
--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -27,7 +27,7 @@ RUN conan profile detect --force
 COPY ./foxglove-websocket/conanfile.py /src/foxglove-websocket/conanfile.py
 ARG CPPSTD=17
 ARG ASIO=standalone
-RUN conan install foxglove-websocket -s compiler.cppstd=$CPPSTD --build=missing
+RUN conan install foxglove-websocket -s compiler.cppstd=$CPPSTD -o foxglove-websocket*:asio=$ASIO --build=missing
 COPY ./foxglove-websocket /src/foxglove-websocket/
 RUN conan create foxglove-websocket -s compiler.cppstd=$CPPSTD -o foxglove-websocket*:asio=$ASIO -c tools.build:cxxflags="['-Werror']"
 

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -29,7 +29,7 @@ ARG CPPSTD=17
 ARG ASIO=standalone
 RUN conan install foxglove-websocket -s compiler.cppstd=$CPPSTD --build=missing
 COPY ./foxglove-websocket /src/foxglove-websocket/
-RUN conan create foxglove-websocket -s compiler.cppstd=$CPPSTD -o foxglove-websocket*:asio=$ASIO -c tools.build:cxxflags="['-Wall']"
+RUN conan create foxglove-websocket -s compiler.cppstd=$CPPSTD -o foxglove-websocket*:asio=$ASIO -c tools.build:cxxflags="['-Werror']"
 
 FROM build AS build_examples
 COPY --from=build /root/.conan2 /root/.conan2

--- a/cpp/dev.Dockerfile
+++ b/cpp/dev.Dockerfile
@@ -24,10 +24,12 @@ WORKDIR /src
 FROM base AS build
 RUN pip --no-cache-dir install conan
 RUN conan profile detect --force
-COPY ./foxglove-websocket /src/foxglove-websocket/
+COPY ./foxglove-websocket/conanfile.py /src/foxglove-websocket/conanfile.py
 ARG CPPSTD=17
 ARG ASIO=standalone
-RUN conan create foxglove-websocket -s compiler.cppstd=$CPPSTD --build=missing -o foxglove-websocket*:asio=$ASIO
+RUN conan install foxglove-websocket -s compiler.cppstd=$CPPSTD --build=missing
+COPY ./foxglove-websocket /src/foxglove-websocket/
+RUN conan create foxglove-websocket -s compiler.cppstd=$CPPSTD -o foxglove-websocket*:asio=$ASIO -c tools.build:cxxflags="['-Wall']"
 
 FROM build AS build_examples
 COPY --from=build /root/.conan2 /root/.conan2

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -15,9 +15,9 @@ target_link_libraries(foxglove_websocket nlohmann_json::nlohmann_json websocketp
 set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
-  target_compile_options(foxglove_websocket PRIVATE /WX /W4)
+  target_compile_options(foxglove_websocket PRIVATE /W4)
 else()
-  target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Werror -Wold-style-cast -Wfloat-equal)
+  target_compile_options(foxglove_websocket PRIVATE -Wextra -Wpedantic -Werror -Wold-style-cast -Wfloat-equal)
 endif()
 
 install(TARGETS foxglove_websocket)

--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -17,7 +17,7 @@ set_target_properties(foxglove_websocket PROPERTIES CXX_STANDARD 17 CXX_STANDARD
 if (MSVC)
   target_compile_options(foxglove_websocket PRIVATE /W4)
 else()
-  target_compile_options(foxglove_websocket PRIVATE -Wextra -Wpedantic -Werror -Wold-style-cast -Wfloat-equal)
+  target_compile_options(foxglove_websocket PRIVATE -Wall -Wextra -Wpedantic -Wold-style-cast -Wfloat-equal)
 endif()
 
 install(TARGETS foxglove_websocket)


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Only enable all warnings for CI builds

Motivation: https://github.com/conan-io/conan-center-index/pull/24761#pullrequestreview-2208180113