### PR TITLE
Add option to build as an ament package

### DIFF
--- a/cpp/foxglove-websocket/CMakeLists.txt
+++ b/cpp/foxglove-websocket/CMakeLists.txt
@@ -1,13 +1,21 @@
 cmake_minimum_required(VERSION 3.15)
 project(FoxgloveWebSocket CXX)
 
+find_package(ament_cmake QUIET)
+set(COMPILING_FOR_ROS2 OFF)
+if(${ament_cmake_FOUND})
+  set(COMPILING_FOR_ROS2 ON)
+  message(STATUS "Compiling for ROS2")
+endif()
+
 find_package(nlohmann_json REQUIRED)
 find_package(websocketpp REQUIRED)
 
 add_library(foxglove_websocket src/base64.cpp src/parameter.cpp src/serialization.cpp src/server_factory.cpp)
 target_include_directories(foxglove_websocket
-    PUBLIC include
-    SYSTEM
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
     ${nlohmann_json_INCLUDE_DIRS}
     ${websocketpp_INCLUDE_DIRS}
 )
@@ -21,6 +29,24 @@ else()
 endif()
 
 install(TARGETS foxglove_websocket)
-INSTALL (DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+install(
+  TARGETS foxglove_websocket
+  EXPORT FoxgloveWebSocketTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+INSTALL (DIRECTORY include/
          DESTINATION include)
 install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses/)
+
+if(COMPILING_FOR_ROS2)
+  ament_target_dependencies(foxglove_websocket nlohmann_json websocketpp)
+
+  ament_export_targets(FoxgloveWebSocketTargets HAS_LIBRARY_TARGET)
+  ament_export_dependencies(nlohmann_json websocketpp)
+  ament_export_include_directories(include)
+  ament_export_libraries(foxglove_websocket)
+  ament_package()
+endif()

--- a/cpp/foxglove-websocket/package.xml
+++ b/cpp/foxglove-websocket/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>FoxgloveWebSocket</name>
+  <version>1.3.0</version>
+  <description>Websocket protocol librory for use with foxglove studio</description>
+  <maintainer email="help@foxglove.com">maintainer_name</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>libwebsocketpp-dev</depend>
+  <depend>zlib</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
### Changelog
Add a `package.xml` and update the `CMakeLists.txt` to optionally allow users to build as an ament package.

### Docs

None

### Description

I added a `package.xml` and some updates to the `CMakeLists.txt` so this package could be used in ros2 workspaces. Note that this should only have an affect if it is already in a ros2 workspace and the `ament_cmake` package is found. If not then it should continue to compile as before.

### Help Needed
I wasn't sure what to put for some of the fields in the `package.xml`, so if this is acceptable feel free to edit and modify maintainer info or you can tell me what it should be and i'll add it. Thanks!
