### PR TITLE
call action handlers after action, in c++ server

### DIFF
--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -1340,10 +1340,10 @@ void Server<ServerConfiguration>::handleAdvertise(const nlohmann::json& payload,
     advertisement.encoding = chan.at("encoding").get<std::string>();
     advertisement.schemaName = chan.at("schemaName").get<std::string>();
 
+    clientPublications.emplace(channelId, advertisement);
     {
       std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);
       _clients.at(hdl).advertisedChannels.emplace(channelId);
-      clientPublications.emplace(channelId, advertisement);
     }
     _handlers.clientAdvertiseHandler(advertisement, hdl);
   }


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Guarantees that action handlers in C++ ws server are called after the action has been applied.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

https://github.com/orgs/foxglove/discussions/1049

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

#### Problem

In C++ server, handlers for below events are called before the internal states are fully updated:
* subscribe
* unsubscribe
* client advertise
* client unadvertise
* subscribe connection graph

As a consequence, some user behavior does not work as expected, such as calling `sendMessage()` for messages of the requested topic inside of subscription handler. When subscription handler is called, the internal state does not recognize the requested topic as subscribed, and `sendMessage()` filters out this unsubscribed topic.

This seems to be a bug rather than a spec, because typescript and python server implementations calls listener/emit event after all internal tables are updated.

#### Changes

For the above events, switch the order of handler call and internal map updates.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

https://linear.app/foxglove/issue/FG-9181/c-foxglove-websocket-server-ambiguous-handler-invoke-timing