### PR TITLE
Remove typescript-eslint dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,6 @@ updates:
       interval: weekly
     labels: [] # disable default labels
 
-    # Define groups of dependencies to be updated together
-    # https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
-    groups:
-      eslint:
-        patterns:
-          - "@typescript-eslint/*"
-
   - package-ecosystem: pip
     directory: "/"
     schedule:


### PR DESCRIPTION
We no longer depend on these packages.