### PR TITLE
C++: add missing implementations for client advertised schema/encoding

### DIFF
--- a/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/common.hpp
@@ -79,7 +79,8 @@ struct ClientAdvertisement {
   std::string topic;
   std::string encoding;
   std::string schemaName;
-  std::vector<uint8_t> schema;
+  std::optional<std::string> schema;
+  std::optional<std::string> schemaEncoding;
 };
 
 struct ClientMessage {

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_client.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_client.hpp
@@ -23,6 +23,12 @@ inline void to_json(nlohmann::json& j, const ClientAdvertisement& p) {
                      {"topic", p.topic},
                      {"encoding", p.encoding},
                      {"schemaName", p.schemaName}};
+  if (p.schema) {
+    j["schema"] = *p.schema;
+  }
+  if (p.schemaEncoding) {
+    j["schemaEncoding"] = *p.schemaEncoding;
+  }
 }
 
 using TextMessageHandler = std::function<void(const std::string&)>;

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_client.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_client.hpp
@@ -24,10 +24,10 @@ inline void to_json(nlohmann::json& j, const ClientAdvertisement& p) {
                      {"encoding", p.encoding},
                      {"schemaName", p.schemaName}};
   if (p.schema) {
-    j["schema"] = *p.schema;
+    j["schema"] = p.schema.value();
   }
   if (p.schemaEncoding) {
-    j["schemaEncoding"] = *p.schemaEncoding;
+    j["schemaEncoding"] = p.schemaEncoding.value();
   }
 }
 

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -1340,6 +1340,14 @@ void Server<ServerConfiguration>::handleAdvertise(const nlohmann::json& payload,
     advertisement.encoding = chan.at("encoding").get<std::string>();
     advertisement.schemaName = chan.at("schemaName").get<std::string>();
 
+    advertisement.schema = chan.find("schema") == chan.end()
+                             ? std::nullopt
+                             : std::optional<std::string>(chan["schema"].get<std::string>());
+    advertisement.schemaEncoding =
+      chan.find("schemaEncoding") == chan.end()
+        ? std::nullopt
+        : std::optional<std::string>(chan["schemaEncoding"].get<std::string>());
+
     clientPublications.emplace(channelId, advertisement);
     {
       std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);

--- a/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
+++ b/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp
@@ -1340,14 +1340,12 @@ void Server<ServerConfiguration>::handleAdvertise(const nlohmann::json& payload,
     advertisement.encoding = chan.at("encoding").get<std::string>();
     advertisement.schemaName = chan.at("schemaName").get<std::string>();
 
-    advertisement.schema = chan.find("schema") == chan.end()
-                             ? std::nullopt
-                             : std::optional<std::string>(chan["schema"].get<std::string>());
-    advertisement.schemaEncoding =
-      chan.find("schemaEncoding") == chan.end()
-        ? std::nullopt
-        : std::optional<std::string>(chan["schemaEncoding"].get<std::string>());
-
+    if (const auto it = chan.find("schema"); it != chan.end()) {
+      advertisement.schema = it->get<std::string>();
+    }
+    if (const auto it = chan.find("schemaEncoding"); it != chan.end()) {
+      advertisement.schemaEncoding = it->get<std::string>();
+    }
     clientPublications.emplace(channelId, advertisement);
     {
       std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

C++ server/client: add missing implementations for client advertised schema / schema encoding

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

* Issue #875 (Initial discussions are here)
* Liner Ticket FG-9447 (though I can't access to it)

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

Although foxglove ws protocol allow client to advertise complete schema definition string as well as schema name, current C++ implementation lacks such fields. Particularly:
* `ClientAdvertisement` struct lacks `schemaEncoding` field,
* `ClientAdvertisement` struct has `schema` field, but it is never populated (websocket server does not read schema or schema encoding to json)
* websocket client is does not serialize schema or schema encoding to json

This PR resolves above problems, and additionally since this is breaking change from unimplemented to implemented, types are decided as following:
* `schema` field type is changed from `std::vector<uint8_t>` to `std::optional<std::string>`, as schema fields are passed in as json quoted string, and it's optional
* `schemaEncoding` field type is determined as `std::optional<std::string>`, the same reason for `schema`.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

Fixes: foxglove/ws-protocol#875
Fixes: FG-9447
