### PR TITLE
mcap-record: Add support for omgidl schemas

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/mcap-record.ts
+++ b/typescript/ws-protocol-examples/src/examples/mcap-record.ts
@@ -160,6 +160,7 @@ async function main(
                 json: "jsonschema",
                 protobuf: "protobuf",
                 flatbuffer: "flatbuffer",
+                omgidl: "omgidl",
                 ros1: "ros1msg",
                 ros2: "ros2msg",
               }[channel.encoding];
@@ -174,6 +175,7 @@ async function main(
             let schemaData: Uint8Array | undefined;
             switch (schemaEncoding) {
               case "jsonschema":
+              case "omgidl":
               case "ros1msg":
               case "ros2msg":
                 schemaData = textEncoder.encode(channel.schema);


### PR DESCRIPTION
### Changelog
Add support for omgidl schemas in mcap-record

### Docs
None

### Description
Recording channels with `omgidl` schema currently yields the following warning:
```
unknown schema encoding omgidl, messages will be recorded without schema
```

This PR adds `omgidl` as a known encoding
