### PR TITLE
[typescript] Allow client to understand other subprotocols

### DIFF
--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -58,6 +58,8 @@ const textEncoder = new TextEncoder();
  * "foxglove.websocket.v1").
  */
 export default class FoxgloveClient {
+  static SUPPORTED_SUBPROTOCOL = "foxglove.websocket.v1";
+
   #emitter = new EventEmitter<EventTypes>();
   #ws: IWebSocket;
   #nextSubscriptionId = 0;

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -50,7 +50,7 @@ type EventTypes = {
 const textEncoder = new TextEncoder();
 
 /**
- * A client to make it easier to interact with the Foxglove WebSocket protocol:
+ * A client to interact with the Foxglove WebSocket protocol:
  * https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md.
  *
  * You must provide the underlying websocket client (an implementation of `IWebSocket`) and that

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -62,6 +62,11 @@ export default class FoxgloveClient {
     this.#reconnect();
   }
 
+  /**
+   * A list of subprotocols, in order of preference
+   */
+  protected supportedSubprotocols: string[] = [FoxgloveClient.SUPPORTED_SUBPROTOCOL];
+
   on<E extends EventEmitter.EventNames<EventTypes>>(
     name: E,
     listener: EventEmitter.EventListener<EventTypes, E>,
@@ -81,12 +86,9 @@ export default class FoxgloveClient {
       this.#emitter.emit("error", event.error ?? new Error("WebSocket error"));
     };
     this.#ws.onopen = (_event) => {
-      if (this.#ws.protocol !== FoxgloveClient.SUPPORTED_SUBPROTOCOL) {
-        throw new Error(
-          `Expected subprotocol ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}, got '${
-            this.#ws.protocol
-          }'`,
-        );
+      if (!this.supportedSubprotocols.includes(this.#ws.protocol)) {
+        const preferredProtocol = this.supportedSubprotocols[0] ?? "";
+        throw new Error(`Expected subprotocol ${preferredProtocol}, got '${this.#ws.protocol}'`);
       }
       this.#emitter.emit("open");
     };

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -87,8 +87,11 @@ export default class FoxgloveClient {
     };
     this.#ws.onopen = (_event) => {
       if (!this.supportedSubprotocols.includes(this.#ws.protocol)) {
-        const preferredProtocol = this.supportedSubprotocols[0] ?? "";
-        throw new Error(`Expected subprotocol ${preferredProtocol}, got '${this.#ws.protocol}'`);
+        const protocolDesc =
+          this.supportedSubprotocols.length === 1
+            ? `subprotocol '${this.supportedSubprotocols[0]}'`
+            : `a subprotocol from ['${this.supportedSubprotocols.join("', '")}']`;
+        throw new Error(`Expected ${protocolDesc}; got '${this.#ws.protocol}'`);
       }
       this.#emitter.emit("open");
     };

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -63,7 +63,8 @@ export default class FoxgloveClient {
   }
 
   /**
-   * A list of subprotocols, in order of preference
+   * A list subprotocols supported by this client. Typically, this will agree with the subprotocols
+   * advertised by the provided `IWebSocket` implementation.
    */
   protected supportedSubprotocols: string[] = [FoxgloveClient.SUPPORTED_SUBPROTOCOL];
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

This removes the "supported subprotocol" check performed after the handshake, instead relying on the underlying websocket client to advertise the correct subprotocol.

The `FoxgloveClient` already accepts a websocket client (`IWebSocket`), which is free to choose its advertised subprotocols. This change would allow it to be extended with backwards-compatible subprotocols (for example, v2).

This change is not breaking as long as existing clients are advertising the correct subprotocol.