### PR TITLE
Bump typescript ws-protocol to 0.7.5

### DIFF
--- a/typescript/ws-protocol/package.json
+++ b/typescript/ws-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/ws-protocol",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Foxglove WebSocket protocol",
   "keywords": [
     "foxglove",


### PR DESCRIPTION
### Changelog

Remove the explicit check for a supported subprotocol in `FoxgloveClient`. Rely on the WS client to advertise the correct value and the handshake to enforce it.

### Docs

None

### Description

Version bump for #916