### PR TITLE
cpp: specify param type for double / double array parameters

### DIFF
--- a/cpp/foxglove-websocket/src/serialization.cpp
+++ b/cpp/foxglove-websocket/src/serialization.cpp
@@ -76,6 +76,13 @@ void to_json(nlohmann::json& j, const Parameter& p) {
   j["name"] = p.getName();
   if (p.getType() == ParameterType::PARAMETER_BYTE_ARRAY) {
     j["type"] = "byte_array";
+  } else if (p.getType() == ParameterType::PARAMETER_DOUBLE) {
+    j["type"] = "float64";
+  } else if (p.getType() == ParameterType::PARAMETER_ARRAY) {
+    const auto& vec = p.getValue().getValue<std::vector<ParameterValue>>();
+    if (!vec.empty() && vec.front().getType() == ParameterType::PARAMETER_DOUBLE) {
+      j["type"] = "float64_array";
+    }
   }
 }
 
@@ -89,10 +96,26 @@ void from_json(const nlohmann::json& j, Parameter& p) {
 
   ParameterValue pValue;
   from_json(j["value"], pValue);
+  const auto typeIt = j.find("type");
+  const std::string type = typeIt != j.end() ? typeIt->get<std::string>() : "";
 
-  if (j.find("type") != j.end() && j["type"] == "byte_array" &&
-      pValue.getType() == ParameterType::PARAMETER_STRING) {
+  if (pValue.getType() == ParameterType::PARAMETER_STRING && type == "byte_array") {
     p = Parameter(name, base64Decode(pValue.getValue<std::string>()));
+  } else if (pValue.getType() == ParameterType::PARAMETER_INTEGER && type == "float64") {
+    // Explicitly cast integer value to double.
+    p = Parameter(name, static_cast<double>(pValue.getValue<int64_t>()));
+  } else if (pValue.getType() == ParameterType::PARAMETER_ARRAY && type == "float64_array") {
+    // Explicitly cast elements to double, if possible.
+    auto values = pValue.getValue<std::vector<ParameterValue>>();
+    for (ParameterValue& value : values) {
+      if (value.getType() == ParameterType::PARAMETER_INTEGER) {
+        value = ParameterValue(static_cast<double>(value.getValue<int64_t>()));
+      } else if (value.getType() != ParameterType::PARAMETER_DOUBLE) {
+        throw std::runtime_error("Parameter '" + name +
+                                 "' (float64_array) contains non-numeric elements.");
+      }
+    }
+    p = Parameter(name, values);
   } else {
     p = Parameter(name, pValue);
   }


### PR DESCRIPTION
### Changelog
cpp: Add parameter type float64 & float64_array for floating point values

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description
From https://github.com/foxglove/ws-protocol/pull/519:

> Some languages, such as JavaScript, do not differentiate between integers and floating point numbers. The `float64` and `float64_array` types were added to avoid ambiguity by informing the client (or the server) that the value is a floating point number, or an array of it, respectively.

On the foxglove_bridge side this has been implemented in https://github.com/foxglove/ros-foxglove-bridge/pull/256 but that change has apparently never found its way to this repo. This PR applies that change to this repo.

