### PR TITLE
Typescript: Use ArrayBufferView instead of DataView for data types.

### DIFF
--- a/typescript/ws-protocol-examples/src/examples/service-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-client.ts
@@ -57,7 +57,7 @@ async function main(url: string) {
       serviceId: service.id,
       callId: 123,
       encoding: msgEncoding,
-      data: new DataView(requestData.buffer),
+      data: requestData,
     });
   });
 

--- a/typescript/ws-protocol-examples/src/examples/service-server.ts
+++ b/typescript/ws-protocol-examples/src/examples/service-server.ts
@@ -144,7 +144,7 @@ async function main(): Promise<void> {
     }
     const response: ServiceCallPayload = {
       ...request,
-      data: new DataView(responseData.buffer),
+      data: responseData,
     };
     server.sendServiceCallResponse(response, clientConnection);
   });

--- a/typescript/ws-protocol-examples/src/examples/simple-client.ts
+++ b/typescript/ws-protocol-examples/src/examples/simple-client.ts
@@ -14,7 +14,7 @@ async function main(url: string) {
   const client = new FoxgloveClient({
     ws: new WebSocket(address, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
   });
-  const deserializers = new Map<SubscriptionId, (data: DataView) => unknown>();
+  const deserializers = new Map<SubscriptionId, (data: ArrayBufferView) => unknown>();
   client.on("error", (error) => {
     log("Error", error);
     throw error;

--- a/typescript/ws-protocol/src/FoxgloveClient.ts
+++ b/typescript/ws-protocol/src/FoxgloveClient.ts
@@ -91,10 +91,10 @@ export default class FoxgloveClient {
     this.#ws.onopen = (_event) => {
       this.#emitter.emit("open");
     };
-    this.#ws.onmessage = (event: MessageEvent<ArrayBuffer | string>) => {
+    this.#ws.onmessage = (event: MessageEvent<ArrayBuffer | ArrayBufferView | string>) => {
       let message: ServerMessage;
       try {
-        if (event.data instanceof ArrayBuffer) {
+        if (event.data instanceof ArrayBuffer || ArrayBuffer.isView(event.data)) {
           message = parseServerMessage(event.data);
         } else {
           message = JSON.parse(event.data) as ServerMessage;

--- a/typescript/ws-protocol/src/FoxgloveServer.ts
+++ b/typescript/ws-protocol/src/FoxgloveServer.ts
@@ -388,7 +388,7 @@ export default class FoxgloveServer {
     connection.onmessage = (event: MessageEvent<ArrayBuffer | string>) => {
       let message: ClientMessage;
       try {
-        if (event.data instanceof ArrayBuffer) {
+        if (event.data instanceof ArrayBuffer || ArrayBuffer.isView(event.data)) {
           message = parseClientMessage(event.data);
         } else {
           message = JSON.parse(event.data) as ClientMessage;

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -41,7 +41,7 @@ export function parseServerMessage(buffer: ArrayBuffer | ArrayBufferView): Serve
       const encodingBytes = new DataView(view.buffer, view.byteOffset + offset, encodingLength);
       const encoding = textDecoder.decode(encodingBytes);
       offset += encodingLength;
-      const data = new DataView(view.buffer, view.byteOffset + offset, view.byteLength - offset);
+      const data = new Uint8Array(view.buffer, view.byteOffset + offset, view.byteLength - offset);
       return { op, serviceId, callId, encoding, data };
     }
     case BinaryOpcode.FETCH_ASSET_RESPONSE: {
@@ -89,7 +89,7 @@ export function parseClientMessage(buffer: ArrayBuffer | ArrayBufferView): Clien
     case ClientBinaryOpcode.MESSAGE_DATA: {
       const channelId = view.getUint32(offset, true);
       offset += 4;
-      const data = new DataView(view.buffer, view.byteOffset + offset, view.byteLength - offset);
+      const data = new Uint8Array(view.buffer, view.byteOffset + offset, view.byteLength - offset);
       return { op, channelId, data };
     }
     case ClientBinaryOpcode.SERVICE_CALL_REQUEST: {
@@ -102,7 +102,7 @@ export function parseClientMessage(buffer: ArrayBuffer | ArrayBufferView): Clien
       const encodingBytes = new DataView(view.buffer, view.byteOffset + offset, encodingLength);
       const encoding = textDecoder.decode(encodingBytes);
       offset += encodingLength;
-      const data = new DataView(view.buffer, view.byteOffset + offset, view.byteLength - offset);
+      const data = new Uint8Array(view.buffer, view.byteOffset + offset, view.byteLength - offset);
       return { op, serviceId, callId, encoding, data };
     }
   }

--- a/typescript/ws-protocol/src/parse.ts
+++ b/typescript/ws-protocol/src/parse.ts
@@ -12,7 +12,9 @@ export function parseServerMessage(buffer: ArrayBuffer | ArrayBufferView): Serve
   const view =
     buffer instanceof ArrayBuffer
       ? new DataView(buffer)
-      : new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      : buffer instanceof DataView
+        ? buffer
+        : new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 
   let offset = 0;
   const op = view.getUint8(offset);
@@ -79,7 +81,9 @@ export function parseClientMessage(buffer: ArrayBuffer | ArrayBufferView): Clien
   const view =
     buffer instanceof ArrayBuffer
       ? new DataView(buffer)
-      : new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+      : buffer instanceof DataView
+        ? buffer
+        : new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 
   let offset = 0;
   const op = view.getUint8(offset);

--- a/typescript/ws-protocol/src/types.ts
+++ b/typescript/ws-protocol/src/types.ts
@@ -100,14 +100,14 @@ export type ClientUnadvertise = {
 export type ClientMessageData = {
   op: ClientBinaryOpcode.MESSAGE_DATA;
   channelId: ClientChannelId;
-  data: DataView;
+  data: ArrayBufferView;
 };
 
 export type ServiceCallPayload = {
   serviceId: ServiceId;
   callId: number;
   encoding: string;
-  data: DataView;
+  data: ArrayBufferView;
 };
 
 export type ServiceCallRequest = ServiceCallPayload & {
@@ -218,7 +218,7 @@ export type MessageData = {
   op: BinaryOpcode.MESSAGE_DATA;
   subscriptionId: SubscriptionId;
   timestamp: bigint;
-  data: DataView;
+  data: ArrayBufferView;
 };
 export type Time = {
   op: BinaryOpcode.TIME;
@@ -231,7 +231,7 @@ export type FetchAssetSuccessResponse = {
   op: BinaryOpcode.FETCH_ASSET_RESPONSE;
   requestId: number;
   status: FetchAssetStatus.SUCCESS;
-  data: DataView;
+  data: ArrayBufferView;
 };
 export type FetchAssetErrorResponse = {
   op: BinaryOpcode.FETCH_ASSET_RESPONSE;
@@ -248,7 +248,7 @@ export type ServiceCallFailure = {
 };
 export type ClientPublish = {
   channel: ClientChannel;
-  data: DataView;
+  data: ArrayBufferView;
 };
 export type ParameterValue =
   | undefined


### PR DESCRIPTION
### Changelog
Typescript: Use ArrayBufferView instead of DataView for data types.

### Docs
None

### Description
- 65323c5dcc6dc8228bcfc55485984ef162d927e1 changes the typescript client's `onmessage` handler to accept messages of type `ArrayBufferView` (e.g. Uint8Arrays). This gives more flexibility when implementing a custom `IWebSocket` source.
- 6382cea5da3f40ad98c898a651bbd3b28b39793b changes the type of `data` message fields from `DataView` to `ArrayBufferView`. This is a breaking change, but makes the API easier to use.
