### PR TITLE
Add deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Foxglove WebSocket Protocol
 
+> ⚠️ Important Notice: The Foxglove WebSocket Protocol is entering maintenance mode. We recommend migrating to the [Foxglove SDK](https://docs.foxglove.dev/docs/sdk) for future development.
+
 This repository provides a [protocol specification](docs/spec.md) and reference implementations enabling [Foxglove](https://foxglove.dev/) to ingest arbitrary “live” streamed data.
 
 A Foxglove WebSocket server can provide multiple data streams, called _channels_. When a client subscribes to a channel, it begins receiving _messages_ on that channel. This protocol does not prescribe the messages' data format. Instead, the server specifies each channel's _encoding_, and the client uses this information to determine whether it can decode that channel's messages. Read the [Foxglove documentation](https://docs.foxglove.dev/docs/connecting-to-data/frameworks/custom/#live-connection) for more information on which encodings Foxglove supports.
@@ -14,6 +16,6 @@ Implementations are available in the following languages:
 | C++                   | [server + examples](cpp)                    | `foxglove-websocket`             | [![](https://shields.io/conan/v/foxglove-websocket)](https://conan.io/center/foxglove-websocket)                             |
 
 ### Additional resources
+
 - https://foxglove.github.io/ws-protocol - Connect to a ws-protocol compliant server and measure data throughput
 - [eCAL Foxglove Bridge](https://github.com/eclipse-ecal/ecal-foxglove-bridge) – WebSocket bridge that allows users to connect eCAL systems to Foxglove for easy visualization and debugging
-

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,5 +1,8 @@
 # C++ implementation of the Foxglove WebSocket protocol
 
+> ⚠️ Important Notice: This package is no longer maintained and has been replaced by the [Foxglove
+> SDK](https://docs.foxglove.dev/docs/sdk).
+
 ## Instructions
 
 - Run `make build`
@@ -10,6 +13,7 @@ For websocket throughput testing, you can use `make example_server_perf_test` an
 ## Thread safety
 
 The C++ foxglove websocket implementation uses websocketpp which is thread safe. However, you cannot send data through the websocket inside a connection handler callback of the same websocket connection. For example, if you want to implement _message latching_, you might want to flush buffered messages upon client connection (using `subscribeHandler`). But nothing would get sent out inside the callback thread. To fix this, you can simply spin up a new thread. You could do something like:
+
 ```c++
 auto server_ptr = foxglove::ServerFactory::createServer<websocketpp::connection_hdl>(server_name, log_handler, options);
 

--- a/cpp/examples/conanfile.py
+++ b/cpp/examples/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class FoxgloveWebSocketExamplesConan(ConanFile):
     name = "foxglove-websocket-example"
-    version = "1.4.0"
+    version = "1.4.1"
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "CMakeLists.txt", "src/*", "proto/*"
     generators = "CMakeDeps"

--- a/cpp/foxglove-websocket/conanfile.py
+++ b/cpp/foxglove-websocket/conanfile.py
@@ -5,10 +5,10 @@ from conan.tools.build import check_min_cppstd
 
 class FoxgloveWebSocketConan(ConanFile):
     name = "foxglove-websocket"
-    version = "1.4.0"
+    version = "1.4.1"
     url = "https://github.com/foxglove/ws-protocol"
     homepage = "https://github.com/foxglove/ws-protocol"
-    description = "A C++ server implementation of the Foxglove WebSocket Protocol"
+    description = "Deprecated. A C++ server implementation of the Foxglove WebSocket Protocol"
     license = "MIT"
     topics = ("foxglove", "websocket")
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,12 +1,10 @@
 # Foxglove WebSocket server
 
+> ⚠️ Important Notice: This package is no longer maintained and has been replaced by
+> [foxglove-sdk](https://pypi.org/project/foxglove-sdk/). We recommend migrating to the [Foxglove
+> SDK](https://docs.foxglove.dev/docs/sdk) for future development.
+
 This package provides a server implementation of the [Foxglove WebSocket protocol](https://github.com/foxglove/ws-protocol) with examples. The protocol enables [Foxglove](https://foxglove.dev/) to ingest arbitrary “live” streamed data.
-
-## Installation
-
-```
-$ pip install foxglove-websocket
-```
 
 ## Example servers
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = foxglove-websocket
-version = 0.1.3
-description = Foxglove WebSocket server
+version = 0.1.4
+description = Foxglove WebSocket server (deprecated in favor of foxglove-sdk)
 long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = foxglove, websocket, robotics, ros, ros2
@@ -11,6 +11,7 @@ project_urls =
     GitHub Issues = https://github.com/foxglove/ws-protocol/issues
     Foxglove Documentation = https://docs.foxglove.dev/
 classifiers =
+    Development Status :: 7 - Inactive
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent


### PR DESCRIPTION
This adds deprecation notices to the README, and to C++ and Python packages, which are being replaced by the Foxglove SDK (https://github.com/foxglove/foxglove-sdk).

This bumps the version numbers of C++ and Python packages, so that we can publish a patch release with deprecation notices on those repositories.