### PR TITLE
Skip attestations for test publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           packages_dir: python/dist
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/releases/python/v') }}


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

PyPI publishing is failing. See https://github.com/foxglove/foxglove-sdk/pull/158:

> Running a publish to TestPyPI immediately followed by a publish to the "real" PyPI triggered an error due to a file already existing. The workaround recommended in https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440 is to set attestations: false on the TestPyPI publish.

This removes attestations from the Test publish step as described above.

I'll either need to tag v0.1.5 as the next release, or move the v0.1.4 tag which I created a little while ago.